### PR TITLE
Add interactive D&D character creation flow

### DIFF
--- a/cogs/character_creation.py
+++ b/cogs/character_creation.py
@@ -1,0 +1,330 @@
+"""Interactive character creation flow using Discord components."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from dnd import (
+    ABILITY_NAMES,
+    AVAILABLE_CLASSES,
+    AVAILABLE_RACES,
+    AbilityScores,
+    Character,
+    CharacterRepository,
+)
+
+
+class RaceSelect(discord.ui.Select[discord.ui.View]):
+    def __init__(self, view: "CharacterCreationView") -> None:
+        self._creation_view = view
+        options = [
+            discord.SelectOption(
+                label=race.name,
+                description=race.description[:100],
+            )
+            for race in AVAILABLE_RACES.values()
+        ]
+        super().__init__(
+            placeholder="Choose a race",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        self._creation_view.selected_race = self.values[0]
+        await self._creation_view.refresh(interaction)
+
+
+class ClassSelect(discord.ui.Select[discord.ui.View]):
+    def __init__(self, view: "CharacterCreationView") -> None:
+        self._creation_view = view
+        options = [
+            discord.SelectOption(
+                label=character_class.name,
+                description=f"Primary: {character_class.primary_ability}",
+            )
+            for character_class in AVAILABLE_CLASSES.values()
+        ]
+        super().__init__(
+            placeholder="Choose a class",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        self._creation_view.selected_class = self.values[0]
+        await self._creation_view.refresh(interaction)
+
+
+class AbilityScoreModal(discord.ui.Modal, title="Assign Ability Scores"):
+    def __init__(self, view: "CharacterCreationView") -> None:
+        super().__init__(timeout=180)
+        self._creation_view = view
+        self.inputs: Dict[str, discord.ui.TextInput] = {}
+        for ability in ABILITY_NAMES:
+            default = (
+                str(view.ability_scores.values.get(ability))
+                if view.ability_scores
+                else ""
+            )
+            input_field = discord.ui.TextInput(
+                label=f"{ability} score",
+                placeholder="Use the standard array values",
+                default=default,
+                required=True,
+                max_length=2,
+            )
+            self.add_item(input_field)
+            self.inputs[ability] = input_field
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        try:
+            assignments = {ability: int(field.value) for ability, field in self.inputs.items()}
+            scores = AbilityScores.from_assignments(assignments, method="standard_array")
+        except ValueError as exc:
+            await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
+            return
+
+        self._creation_view.set_ability_scores(scores)
+        await interaction.response.send_message(
+            "✅ Ability scores updated using the standard array.",
+            ephemeral=True,
+        )
+        await self._creation_view.refresh()
+
+
+class AbilityScoreButton(discord.ui.Button[discord.ui.View]):
+    def __init__(self, view: "CharacterCreationView") -> None:
+        super().__init__(label="Assign ability scores", style=discord.ButtonStyle.primary)
+        self._creation_view = view
+
+    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        modal = AbilityScoreModal(self._creation_view)
+        await interaction.response.send_modal(modal)
+
+
+class ResetButton(discord.ui.Button[discord.ui.View]):
+    def __init__(self, view: "CharacterCreationView") -> None:
+        super().__init__(label="Reset choices", style=discord.ButtonStyle.secondary)
+        self._creation_view = view
+
+    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        self._creation_view.reset()
+        await interaction.response.edit_message(
+            embed=self._creation_view.build_embed(),
+            view=self._creation_view,
+        )
+
+
+class ConfirmButton(discord.ui.Button[discord.ui.View]):
+    def __init__(self, view: "CharacterCreationView") -> None:
+        super().__init__(label="Confirm character", style=discord.ButtonStyle.success, disabled=True)
+        self._creation_view = view
+
+    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        await interaction.response.defer(ephemeral=True, thinking=True)
+
+        view = self._creation_view
+        if not interaction.guild:
+            await interaction.followup.send("This command can only be used in a server.", ephemeral=True)
+            return
+
+        if await view.repository.exists(interaction.guild.id, interaction.user.id):
+            await interaction.followup.send(
+                "You already have a character saved. Reset first if you want to recreate it.",
+                ephemeral=True,
+            )
+            return
+
+        ability_scores = view.ability_scores
+        if not (view.selected_race and view.selected_class and ability_scores):
+            await interaction.followup.send(
+                "Please complete all steps before confirming.",
+                ephemeral=True,
+            )
+            return
+
+        race = AVAILABLE_RACES[view.selected_race]
+        character_class = AVAILABLE_CLASSES[view.selected_class]
+        character = Character(
+            guild_id=interaction.guild.id,
+            user_id=interaction.user.id,
+            race=race,
+            character_class=character_class,
+            ability_scores=ability_scores,
+            name=f"{interaction.user.display_name}'s Adventurer",
+        )
+        await view.repository.save(character)
+
+        confirmation_embed = view.build_confirmation_embed(interaction.user, character)
+        if view.message:
+            await view.message.edit(embed=confirmation_embed, view=None)
+        await interaction.followup.send("Character saved successfully!", ephemeral=True)
+        view.stop()
+
+
+class CharacterCreationView(discord.ui.View):
+    def __init__(self, repository: CharacterRepository, user: discord.abc.User) -> None:
+        super().__init__(timeout=600)
+        self.repository = repository
+        self.user = user
+        self.selected_race: Optional[str] = None
+        self.selected_class: Optional[str] = None
+        self.ability_scores: Optional[AbilityScores] = None
+        self.message: Optional[discord.Message] = None
+
+        self.race_select = RaceSelect(self)
+        self.class_select = ClassSelect(self)
+        self.ability_button = AbilityScoreButton(self)
+        self.reset_button = ResetButton(self)
+        self.confirm_button = ConfirmButton(self)
+
+        self.add_item(self.race_select)
+        self.add_item(self.class_select)
+        self.add_item(self.ability_button)
+        self.add_item(self.reset_button)
+        self.add_item(self.confirm_button)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:  # type: ignore[override]
+        if interaction.user.id != self.user.id:
+            await interaction.response.send_message(
+                "Only the user who initiated the creation can interact with this view.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    async def start(self, interaction: discord.Interaction) -> None:
+        embed = self.build_embed()
+        await interaction.response.send_message(embed=embed, view=self, ephemeral=True)
+        self.message = await interaction.original_response()
+
+    def set_ability_scores(self, scores: AbilityScores) -> None:
+        self.ability_scores = scores
+        self._update_confirm_state()
+
+    def reset(self) -> None:
+        self.selected_race = None
+        self.selected_class = None
+        self.ability_scores = None
+        self._update_confirm_state()
+
+    async def refresh(self, interaction: Optional[discord.Interaction] = None) -> None:
+        self._update_confirm_state()
+        embed = self.build_embed()
+        if interaction is not None:
+            if interaction.response.is_done():
+                await interaction.edit_original_response(embed=embed, view=self)
+            else:
+                await interaction.response.edit_message(embed=embed, view=self)
+        elif self.message:
+            await self.message.edit(embed=embed, view=self)
+
+    def build_embed(self) -> discord.Embed:
+        description = (
+            "Use the menus and buttons below to assemble your adventurer. "
+            "Ability scores use the D&D 5e standard array (15, 14, 13, 12, 10, 8)."
+        )
+        embed = discord.Embed(title="D&D Character Creation", description=description, colour=discord.Colour.blurple())
+        embed.add_field(
+            name="Race",
+            value=self.selected_race or "Not selected",
+            inline=False,
+        )
+        embed.add_field(
+            name="Class",
+            value=self.selected_class or "Not selected",
+            inline=False,
+        )
+        if self.ability_scores:
+            embed.add_field(
+                name="Ability Scores",
+                value="\n".join(self.ability_scores.as_lines()),
+                inline=False,
+            )
+        else:
+            embed.add_field(
+                name="Ability Scores",
+                value="Not assigned",
+                inline=False,
+            )
+        embed.set_footer(text="Confirm to save your character once all steps are complete.")
+        return embed
+
+    def build_confirmation_embed(
+        self, user: discord.abc.User, character: Character
+    ) -> discord.Embed:
+        embed = discord.Embed(
+            title=f"{character.name}",
+            description=f"{user.mention}'s freshly forged adventurer",
+            colour=discord.Colour.green(),
+        )
+        embed.add_field(name="Race", value=character.race.name, inline=True)
+        embed.add_field(name="Class", value=character.character_class.name, inline=True)
+        embed.add_field(
+            name="Ability Scores",
+            value="\n".join(character.ability_scores.as_lines()),
+            inline=False,
+        )
+        embed.set_footer(text="Character saved. Use future commands to view or manage it.")
+        return embed
+
+    def _update_confirm_state(self) -> None:
+        self.confirm_button.disabled = not (
+            self.selected_race and self.selected_class and self.ability_scores
+        )
+
+    async def on_timeout(self) -> None:
+        if self.message:
+            timeout_embed = self.build_embed()
+            timeout_embed.set_footer(
+                text="Session expired. Run /character create again to restart."
+            )
+            await self.message.edit(embed=timeout_embed, view=None)
+
+
+class CharacterCreation(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.repository = CharacterRepository(Path("data") / "characters.json")
+
+    character_group = app_commands.Group(
+        name="character", description="Create and manage D&D characters"
+    )
+
+    @character_group.command(name="create", description="Create a new D&D character")
+    async def character_create(self, interaction: discord.Interaction) -> None:
+        if not interaction.guild:
+            await interaction.response.send_message(
+                "Character creation is only available inside servers.",
+                ephemeral=True,
+            )
+            return
+
+        existing = await self.repository.exists(interaction.guild.id, interaction.user.id)
+        if existing:
+            await interaction.response.send_message(
+                "You already have a saved character. Reset or delete it before creating another.",
+                ephemeral=True,
+            )
+            return
+
+        view = CharacterCreationView(self.repository, interaction.user)
+        await view.start(interaction)
+
+    async def cog_load(self) -> None:
+        self.bot.tree.add_command(self.character_group)
+
+    async def cog_unload(self) -> None:
+        self.bot.tree.remove_command(self.character_group.name, type=self.character_group.type)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(CharacterCreation(bot))

--- a/dnd/__init__.py
+++ b/dnd/__init__.py
@@ -1,0 +1,23 @@
+"""DnD helper models and repositories."""
+
+from .characters import (
+    ABILITY_NAMES,
+    AVAILABLE_CLASSES,
+    AVAILABLE_RACES,
+    AbilityScores,
+    Character,
+    CharacterClass,
+    Race,
+)
+from .repository import CharacterRepository
+
+__all__ = [
+    "ABILITY_NAMES",
+    "AVAILABLE_CLASSES",
+    "AVAILABLE_RACES",
+    "AbilityScores",
+    "Character",
+    "CharacterClass",
+    "Race",
+    "CharacterRepository",
+]

--- a/dnd/characters.py
+++ b/dnd/characters.py
@@ -1,0 +1,175 @@
+"""Domain models and helpers for Dungeons & Dragons characters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Mapping
+
+ABILITY_NAMES: tuple[str, ...] = ("STR", "DEX", "CON", "INT", "WIS", "CHA")
+STANDARD_ARRAY: tuple[int, ...] = (15, 14, 13, 12, 10, 8)
+POINT_BUY_COSTS: Mapping[int, int] = {
+    8: 0,
+    9: 1,
+    10: 2,
+    11: 3,
+    12: 4,
+    13: 5,
+    14: 7,
+    15: 9,
+}
+POINT_BUY_BUDGET: int = 27
+
+
+@dataclass(frozen=True)
+class Race:
+    """Represents a D&D playable race."""
+
+    name: str
+    description: str
+
+
+@dataclass(frozen=True)
+class CharacterClass:
+    """Represents a D&D character class."""
+
+    name: str
+    hit_die: int
+    primary_ability: str
+
+
+AVAILABLE_RACES: Dict[str, Race] = {
+    race.name: race
+    for race in (
+        Race("Human", "Adaptable and ambitious, humans thrive in any environment."),
+        Race("Elf", "Graceful spellcasters with keen senses and a love for nature."),
+        Race("Dwarf", "Stout warriors renowned for their resilience and craftsmanship."),
+        Race("Halfling", "Nimble travelers with uncanny luck and warm hearts."),
+        Race("Dragonborn", "Descendants of dragons who channel elemental power."),
+        Race("Tiefling", "Planetouched folk wielding innate infernal magic."),
+    )
+}
+
+AVAILABLE_CLASSES: Dict[str, CharacterClass] = {
+    c.name: c
+    for c in (
+        CharacterClass("Fighter", hit_die=10, primary_ability="STR"),
+        CharacterClass("Wizard", hit_die=6, primary_ability="INT"),
+        CharacterClass("Rogue", hit_die=8, primary_ability="DEX"),
+        CharacterClass("Cleric", hit_die=8, primary_ability="WIS"),
+        CharacterClass("Paladin", hit_die=10, primary_ability="CHA"),
+        CharacterClass("Ranger", hit_die=10, primary_ability="DEX"),
+    )
+}
+
+
+@dataclass
+class AbilityScores:
+    """Ability scores for a D&D character."""
+
+    values: Dict[str, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        missing = set(ABILITY_NAMES) - set(self.values)
+        if missing:
+            raise ValueError(f"Missing ability scores for: {', '.join(sorted(missing))}")
+
+    @classmethod
+    def from_assignments(
+        cls,
+        assignments: Mapping[str, int],
+        *,
+        method: str = "standard_array",
+    ) -> "AbilityScores":
+        """Validate and create ability scores using the chosen method."""
+
+        assignments = {key.upper(): int(value) for key, value in assignments.items()}
+        _validate_assignment_keys(assignments)
+
+        if method == "standard_array":
+            _validate_standard_array(assignments.values())
+        elif method == "point_buy":
+            _validate_point_buy(assignments.values())
+        else:
+            raise ValueError("Unknown ability assignment method: %s" % method)
+
+        return cls(dict(assignments))
+
+    def as_lines(self) -> Iterable[str]:
+        return (f"{ability}: {self.values[ability]}" for ability in ABILITY_NAMES)
+
+    def to_dict(self) -> Dict[str, int]:
+        return dict(self.values)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, int]) -> "AbilityScores":
+        return cls(dict(data))
+
+
+@dataclass
+class Character:
+    """Persistent representation of a created character."""
+
+    guild_id: int
+    user_id: int
+    race: Race
+    character_class: CharacterClass
+    ability_scores: AbilityScores
+    name: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "guild_id": self.guild_id,
+            "user_id": self.user_id,
+            "race": self.race.name,
+            "class": self.character_class.name,
+            "ability_scores": self.ability_scores.to_dict(),
+            "name": self.name,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "Character":
+        race_name = str(data["race"])
+        class_name = str(data["class"])
+        race = AVAILABLE_RACES[race_name]
+        character_class = AVAILABLE_CLASSES[class_name]
+        ability_scores = AbilityScores.from_dict(
+            {k: int(v) for k, v in dict(data["ability_scores"]).items()}
+        )
+        return cls(
+            guild_id=int(data["guild_id"]),
+            user_id=int(data["user_id"]),
+            race=race,
+            character_class=character_class,
+            ability_scores=ability_scores,
+            name=str(data.get("name", "Unnamed Adventurer")),
+        )
+
+
+def _validate_assignment_keys(assignments: Mapping[str, int]) -> None:
+    unknown = set(assignments) - set(ABILITY_NAMES)
+    if unknown:
+        raise ValueError(f"Unknown ability names: {', '.join(sorted(unknown))}")
+
+
+def _validate_standard_array(values: Iterable[int]) -> None:
+    sorted_values = sorted(values)
+    if sorted_values != sorted(STANDARD_ARRAY):
+        raise ValueError(
+            "Ability scores must match the standard array: "
+            f"{', '.join(map(str, STANDARD_ARRAY))}"
+        )
+
+
+def _validate_point_buy(values: Iterable[int]) -> None:
+    total_cost = 0
+    for value in values:
+        if value < 8 or value > 15:
+            raise ValueError("Point buy values must be between 8 and 15 inclusive.")
+        if value not in POINT_BUY_COSTS:
+            raise ValueError(f"Point buy does not support the score {value}.")
+        total_cost += POINT_BUY_COSTS[value]
+    if total_cost > POINT_BUY_BUDGET:
+        raise ValueError(
+            "Point buy total exceeds budget of "
+            f"{POINT_BUY_BUDGET} points (used {total_cost})."
+        )

--- a/dnd/repository.py
+++ b/dnd/repository.py
@@ -1,0 +1,79 @@
+"""Concurrency-safe persistence helpers for characters."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+from .characters import Character
+
+
+class CharacterRepository:
+    """Store characters per guild and user backed by disk."""
+
+    def __init__(self, storage_path: Path) -> None:
+        self._storage_path = storage_path
+        self._lock = asyncio.Lock()
+        self._cache: Dict[str, Dict[str, Dict[str, object]]] = {}
+        self._loaded = False
+
+    async def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        if not self._storage_path.exists():
+            self._storage_path.parent.mkdir(parents=True, exist_ok=True)
+            self._cache = {}
+            self._loaded = True
+            return
+        data = await asyncio.to_thread(self._storage_path.read_text)
+        if data.strip():
+            try:
+                raw = json.loads(data)
+            except json.JSONDecodeError:
+                self._cache = {}
+            else:
+                if isinstance(raw, dict):
+                    self._cache = {
+                        str(guild_id): {
+                            str(user_id): dict(character)
+                            for user_id, character in guild_bucket.items()
+                        }
+                        for guild_id, guild_bucket in raw.items()
+                    }
+        self._loaded = True
+
+    async def _persist(self) -> None:
+        text = json.dumps(self._cache, indent=2, sort_keys=True)
+        await asyncio.to_thread(self._storage_path.write_text, text)
+
+    async def get(self, guild_id: int, user_id: int) -> Optional[Character]:
+        async with self._lock:
+            await self._ensure_loaded()
+            guild_bucket = self._cache.get(str(guild_id), {})
+            raw = guild_bucket.get(str(user_id))
+            return Character.from_dict(raw) if raw else None
+
+    async def exists(self, guild_id: int, user_id: int) -> bool:
+        async with self._lock:
+            await self._ensure_loaded()
+            guild_bucket = self._cache.get(str(guild_id), {})
+            return str(user_id) in guild_bucket
+
+    async def save(self, character: Character) -> None:
+        async with self._lock:
+            await self._ensure_loaded()
+            guild_bucket = self._cache.setdefault(str(character.guild_id), {})
+            guild_bucket[str(character.user_id)] = character.to_dict()
+            await self._persist()
+
+    async def clear(self, guild_id: int, user_id: int) -> None:
+        async with self._lock:
+            await self._ensure_loaded()
+            guild_bucket = self._cache.get(str(guild_id))
+            if guild_bucket and str(user_id) in guild_bucket:
+                del guild_bucket[str(user_id)]
+                if not guild_bucket:
+                    del self._cache[str(guild_id)]
+                await self._persist()


### PR DESCRIPTION
## Summary
- add a character creation slash command with embeds and Discord UI controls for choosing race, class, and ability scores
- define reusable D&D character models and validation helpers
- introduce a concurrency-safe repository backed by disk storage for saving created characters

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dc95258b488329b46f8d06ecc505c6