### PR TITLE
Add dungeon generation module and slash commands

### DIFF
--- a/cogs/dungeon.py
+++ b/cogs/dungeon.py
@@ -1,0 +1,273 @@
+"""Dungeon crawling commands and views."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Tuple
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from dnd.combat import saving_throw
+from dnd.dungeon import Dungeon, DungeonGenerator, Room, Theme, ThemeRegistry
+
+
+def _default_data_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "data" / "themes"
+
+
+@dataclass
+class DungeonRun:
+    dungeon: Dungeon
+    current_room: int = 0
+    seed: int | None = None
+
+    @property
+    def room(self) -> Room:
+        return self.dungeon.rooms[self.current_room]
+
+    def travel_description(self) -> str | None:
+        if self.current_room == 0:
+            return None
+        for corridor in self.dungeon.corridors:
+            if corridor.to_room == self.current_room:
+                return corridor.description
+        return None
+
+
+class DungeonNavigationView(discord.ui.View):
+    def __init__(self, cog: "DungeonCog", run_key: Tuple[int, int]) -> None:
+        super().__init__(timeout=900)
+        self.cog = cog
+        self.run_key = run_key
+        self.message: Optional[discord.Message] = None
+
+    async def on_timeout(self) -> None:  # noqa: D401 - discord.py hook
+        run = self.cog.active_runs.pop(self.run_key, None)
+        if run is None:
+            return
+        for item in self.children:
+            if isinstance(item, discord.ui.Button):
+                item.disabled = True
+        if self.message:
+            try:
+                await self.message.edit(content="The expedition grows quiet as the magic fades.", view=self)
+            except discord.HTTPException:
+                pass
+
+    @discord.ui.button(label="Proceed", style=discord.ButtonStyle.primary)
+    async def proceed(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:  # noqa: D401
+        await self.cog.handle_proceed(interaction, self)
+
+    @discord.ui.button(label="Search", style=discord.ButtonStyle.secondary)
+    async def search(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:  # noqa: D401
+        await self.cog.handle_search(interaction)
+
+    @discord.ui.button(label="Disarm Trap", style=discord.ButtonStyle.danger)
+    async def disarm(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:  # noqa: D401
+        await self.cog.handle_disarm(interaction)
+
+
+class DungeonCog(commands.Cog):
+    """Slash commands to generate and explore procedural dungeons."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        data_path = _default_data_path()
+        self.theme_registry = ThemeRegistry.load_from_path(data_path)
+        self.active_runs: Dict[Tuple[int, int], DungeonRun] = {}
+
+    def cog_unload(self) -> None:  # noqa: D401 - discord.py hook
+        try:
+            self.bot.tree.remove_command(self.dungeon_group.name, type=self.dungeon_group.type)
+        except (app_commands.CommandTreeException, KeyError):
+            pass
+
+    # ---- Command helpers -------------------------------------------------
+    def _run_key(self, interaction: discord.Interaction) -> Tuple[int, int]:
+        guild_id = interaction.guild_id or interaction.user.id
+        channel_id = interaction.channel_id or interaction.user.id
+        return (guild_id, channel_id)
+
+    def _resolve_theme(self, name: str | None) -> Theme:
+        if name:
+            return self.theme_registry.get(name)
+        try:
+            return next(iter(self.theme_registry.values()))
+        except StopIteration as exc:
+            raise RuntimeError("No dungeon themes are available") from exc
+
+    def _build_room_embed(self, run: DungeonRun) -> discord.Embed:
+        room = run.room
+        dungeon = run.dungeon
+        embed = discord.Embed(
+            title=f"{dungeon.name} — Room {room.id + 1}: {room.name}",
+            description=room.description,
+            color=discord.Color.dark_purple(),
+        )
+        embed.add_field(name="Encounter", value=room.encounter.summary or "Quiet for now.", inline=False)
+
+        if room.encounter.monsters:
+            monsters = "\n".join(
+                f"• {monster.name} (AC {monster.armor_class}, HP {monster.hit_points})"
+                for monster in room.encounter.monsters
+            )
+            embed.add_field(name="Monsters", value=monsters, inline=False)
+
+        if room.encounter.traps:
+            trap_lines = []
+            for trap in room.encounter.traps:
+                dc = trap.saving_throw.get("dc") if trap.saving_throw else None
+                ability = trap.saving_throw.get("ability") if trap.saving_throw else None
+                detail = f"DC {dc} {ability} save" if dc and ability else "Hidden hazard"
+                trap_lines.append(f"• {trap.name} ({detail})")
+            embed.add_field(name="Traps", value="\n".join(trap_lines), inline=False)
+
+        if room.encounter.loot:
+            loot_lines = [f"• {item.name} ({item.rarity})" for item in room.encounter.loot]
+            embed.add_field(name="Loot", value="\n".join(loot_lines), inline=False)
+
+        travel = run.travel_description()
+        if travel:
+            embed.add_field(name="Approach", value=travel, inline=False)
+
+        footer_parts = [f"Theme: {dungeon.theme.name}"]
+        if dungeon.seed is not None:
+            footer_parts.append(f"Seed: {dungeon.seed}")
+        embed.set_footer(text=" • ".join(footer_parts))
+        return embed
+
+    # ---- Slash commands --------------------------------------------------
+    dungeon_group = app_commands.Group(name="dungeon", description="Procedural dungeon exploration")
+
+    @dungeon_group.command(name="start", description="Generate a themed dungeon and begin exploring.")
+    @app_commands.describe(theme="Name of the dungeon theme to use", rooms="Number of rooms to generate", seed="Optional RNG seed")
+    async def start(
+        self,
+        interaction: discord.Interaction,
+        theme: Optional[str] = None,
+        rooms: app_commands.Range[int, 1, 20] = 5,
+        seed: Optional[int] = None,
+    ) -> None:
+        if not self.theme_registry.values():
+            await interaction.response.send_message(
+                "No dungeon themes are available. Please add files under data/themes.",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            theme_obj = self._resolve_theme(theme)
+        except KeyError:
+            available = ", ".join(sorted(t.name for t in self.theme_registry.values()))
+            await interaction.response.send_message(
+                f"Unknown theme '{theme}'. Available themes: {available}.",
+                ephemeral=True,
+            )
+            return
+
+        if seed is None:
+            seed = random.randint(0, 999999)
+        generator = DungeonGenerator(theme_obj, seed=seed)
+        dungeon = generator.generate(room_count=int(rooms))
+        run = DungeonRun(dungeon=dungeon, seed=seed)
+        key = self._run_key(interaction)
+        self.active_runs[key] = run
+
+        embed = self._build_room_embed(run)
+        view = DungeonNavigationView(self, key)
+
+        await interaction.response.send_message(embed=embed, view=view)
+        view.message = await interaction.original_response()
+
+    @start.autocomplete("theme")
+    async def theme_autocomplete(
+        self, interaction: discord.Interaction, current: str
+    ) -> Iterable[app_commands.Choice[str]]:
+        names = [theme.name for theme in self.theme_registry.values()]
+        filtered = [name for name in names if current.lower() in name.lower()][:25]
+        return [app_commands.Choice(name=name, value=name) for name in filtered]
+
+    # ---- Interaction handlers -------------------------------------------
+    async def handle_proceed(self, interaction: discord.Interaction, view: DungeonNavigationView) -> None:
+        key = self._run_key(interaction)
+        run = self.active_runs.get(key)
+        if run is None:
+            await interaction.response.send_message("No active dungeon for this party.", ephemeral=True)
+            return
+
+        if run.current_room >= len(run.dungeon.rooms) - 1:
+            for item in view.children:
+                if isinstance(item, discord.ui.Button):
+                    item.disabled = True
+            self.active_runs.pop(key, None)
+            await interaction.response.edit_message(view=view)
+            await interaction.followup.send(
+                "The party has already reached the end of this dungeon!",
+                ephemeral=True,
+            )
+            return
+
+        run.current_room += 1
+        embed = self._build_room_embed(run)
+        new_view = DungeonNavigationView(self, key)
+        new_view.message = interaction.message
+
+        await interaction.response.edit_message(embed=embed, view=new_view)
+
+    async def handle_search(self, interaction: discord.Interaction) -> None:
+        key = self._run_key(interaction)
+        run = self.active_runs.get(key)
+        if run is None:
+            await interaction.response.send_message("No active dungeon to search.", ephemeral=True)
+            return
+
+        loot = run.room.encounter.loot
+        if not loot:
+            await interaction.response.send_message("You find nothing of value after a thorough search.", ephemeral=True)
+            return
+
+        lines = [f"• {item.name} ({item.rarity})" for item in loot]
+        await interaction.response.send_message(
+            "You uncover hidden items:\n" + "\n".join(lines),
+            ephemeral=True,
+        )
+
+    async def handle_disarm(self, interaction: discord.Interaction) -> None:
+        key = self._run_key(interaction)
+        run = self.active_runs.get(key)
+        if run is None:
+            await interaction.response.send_message("No traps challenge the party right now.", ephemeral=True)
+            return
+
+        traps = run.room.encounter.traps
+        if not traps:
+            await interaction.response.send_message("There are no traps present in this room.", ephemeral=True)
+            return
+
+        trap = traps[0]
+        dc = int(trap.saving_throw.get("dc", 15)) if trap.saving_throw else 15
+        ability = str(trap.saving_throw.get("ability", "DEX")) if trap.saving_throw else "DEX"
+
+        # Assume a skilled rogue with a +5 bonus attempts the disarm for quick resolution.
+        result = saving_throw(save_bonus=5, dc=dc)
+        if result.success:
+            message = (
+                f"You expertly disarm the {trap.name}! "
+                f"(Roll {result.total}, DC {dc} {ability} save)"
+            )
+        else:
+            message = (
+                f"The {trap.name} resists your efforts (Roll {result.total}, DC {dc} {ability} save). "
+                "Perhaps try another approach."
+            )
+        await interaction.response.send_message(message, ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:
+    cog = DungeonCog(bot)
+    await bot.add_cog(cog)
+    bot.tree.add_command(cog.dungeon_group)

--- a/data/themes/arcane_ruins.json
+++ b/data/themes/arcane_ruins.json
@@ -1,0 +1,76 @@
+{
+  "name": "Arcane Ruins",
+  "description": "Forgotten sanctums where unstable magic lingers in the air.",
+  "room_templates": [
+    {
+      "name": "Cracked Library",
+      "description": "Shelves of dust-caked tomes collapse around a glowing sigil on the floor.",
+      "encounter_weights": {"combat": 3, "trap": 1, "treasure": 1},
+      "weight": 2,
+      "tags": ["knowledge", "arcane"]
+    },
+    {
+      "name": "Runic Observatory",
+      "description": "Shattered lenses float midair, refracting motes of eldritch light.",
+      "encounter_weights": {"combat": 2, "empty": 1, "treasure": 2},
+      "weight": 1,
+      "tags": ["stars", "ritual"]
+    },
+    {
+      "name": "Planar Rift Chamber",
+      "description": "A thin veil crackles with planar energy, distorting time and sound.",
+      "encounter_weights": {"combat": 2, "trap": 2, "empty": 1},
+      "weight": 1,
+      "tags": ["planar", "hazard"]
+    }
+  ],
+  "monsters": [
+    {
+      "name": "Animated Armor",
+      "challenge": 3,
+      "armor_class": 18,
+      "hit_points": 33,
+      "attack_bonus": 5,
+      "damage": "1d8+3",
+      "ability_scores": {"STR": 14, "DEX": 11, "CON": 13}
+    },
+    {
+      "name": "Spectral Mage",
+      "challenge": 4,
+      "armor_class": 12,
+      "hit_points": 40,
+      "attack_bonus": 6,
+      "damage": "2d8+4",
+      "ability_scores": {"INT": 18, "DEX": 14, "WIS": 12}
+    },
+    {
+      "name": "Arcane Sentinel",
+      "challenge": 5,
+      "armor_class": 17,
+      "hit_points": 68,
+      "attack_bonus": 7,
+      "damage": "2d10+4",
+      "ability_scores": {"STR": 18, "CON": 16, "WIS": 10}
+    }
+  ],
+  "traps": [
+    {
+      "name": "Glyph of Detonation",
+      "description": "A hidden rune unleashes a burst of force when stepped upon.",
+      "saving_throw": {"ability": "DEX", "dc": 15},
+      "damage": "4d6 force"
+    },
+    {
+      "name": "Temporal Snare",
+      "description": "An amber field freezes victims in a loop of slow time.",
+      "saving_throw": {"ability": "WIS", "dc": 14},
+      "damage": null
+    }
+  ],
+  "loot": [
+    {"name": "Spell Scroll of Counterspell", "rarity": "Rare"},
+    {"name": "Wand of the War Mage", "rarity": "Uncommon"},
+    {"name": "Potion of Arcane Recovery", "rarity": "Uncommon"}
+  ],
+  "encounters": {"combat": 4, "trap": 2, "treasure": 2, "empty": 1}
+}

--- a/data/themes/forgotten_catacombs.json
+++ b/data/themes/forgotten_catacombs.json
@@ -1,0 +1,76 @@
+{
+  "name": "Forgotten Catacombs",
+  "description": "Ancient burial halls haunted by restless dead and cloying darkness.",
+  "room_templates": [
+    {
+      "name": "Ossuary Gallery",
+      "description": "Stacks of skulls line the walls while candles gutter in stagnant air.",
+      "encounter_weights": {"combat": 3, "trap": 1, "empty": 1},
+      "weight": 2,
+      "tags": ["undead", "relics"]
+    },
+    {
+      "name": "Sunken Crypt",
+      "description": "Flooded alcoves conceal sarcophagi beneath murky water.",
+      "encounter_weights": {"combat": 2, "trap": 2, "treasure": 1},
+      "weight": 1,
+      "tags": ["water", "hazard"]
+    },
+    {
+      "name": "Chapel of Whispers",
+      "description": "Faint chanting emanates from statues whose mouths have been sewn shut.",
+      "encounter_weights": {"combat": 1, "empty": 2, "treasure": 1},
+      "weight": 1,
+      "tags": ["religious", "mystery"]
+    }
+  ],
+  "monsters": [
+    {
+      "name": "Skeletal Guardian",
+      "challenge": 2,
+      "armor_class": 14,
+      "hit_points": 27,
+      "attack_bonus": 4,
+      "damage": "1d8+2",
+      "ability_scores": {"STR": 13, "DEX": 14, "CON": 15}
+    },
+    {
+      "name": "Ghast",
+      "challenge": 3,
+      "armor_class": 12,
+      "hit_points": 36,
+      "attack_bonus": 5,
+      "damage": "2d6+3",
+      "ability_scores": {"STR": 16, "DEX": 17, "CON": 13}
+    },
+    {
+      "name": "Wight Captain",
+      "challenge": 5,
+      "armor_class": 14,
+      "hit_points": 60,
+      "attack_bonus": 6,
+      "damage": "1d10+4",
+      "ability_scores": {"STR": 16, "DEX": 14, "WIS": 12}
+    }
+  ],
+  "traps": [
+    {
+      "name": "Falling Sarcophagus Lid",
+      "description": "A hidden trigger drops a heavy stone lid from the ceiling.",
+      "saving_throw": {"ability": "DEX", "dc": 13},
+      "damage": "3d10 bludgeoning"
+    },
+    {
+      "name": "Necrotic Miasma",
+      "description": "A swirling cloud of necrotic energy drains warmth and hope.",
+      "saving_throw": {"ability": "CON", "dc": 14},
+      "damage": "3d6 necrotic"
+    }
+  ],
+  "loot": [
+    {"name": "Ruby Eye Gem", "rarity": "Rare"},
+    {"name": "Blessed Reliquary", "rarity": "Uncommon"},
+    {"name": "Potion of Vitality", "rarity": "Rare"}
+  ],
+  "encounters": {"combat": 5, "trap": 3, "treasure": 1, "empty": 1}
+}

--- a/dnd/__init__.py
+++ b/dnd/__init__.py
@@ -9,6 +9,31 @@ from .characters import (
     CharacterClass,
     Race,
 )
+from .combat import (
+    AttackRollResult,
+    Combatant,
+    InitiativeResult,
+    SavingThrowResult,
+    ability_modifier,
+    attack_roll,
+    roll_d20,
+    roll_initiative,
+    saving_throw,
+)
+from .dungeon import (
+    Corridor,
+    Dungeon,
+    DungeonGenerator,
+    EncounterResult,
+    EncounterTable,
+    LootDefinition,
+    MonsterDefinition,
+    Room,
+    RoomTemplate,
+    Theme,
+    ThemeRegistry,
+    TrapDefinition,
+)
 from .repository import CharacterRepository
 
 __all__ = [
@@ -20,4 +45,25 @@ __all__ = [
     "CharacterClass",
     "Race",
     "CharacterRepository",
+    "AttackRollResult",
+    "Combatant",
+    "Corridor",
+    "Dungeon",
+    "DungeonGenerator",
+    "EncounterResult",
+    "EncounterTable",
+    "InitiativeResult",
+    "LootDefinition",
+    "MonsterDefinition",
+    "Room",
+    "RoomTemplate",
+    "Theme",
+    "ThemeRegistry",
+    "SavingThrowResult",
+    "ability_modifier",
+    "attack_roll",
+    "roll_d20",
+    "roll_initiative",
+    "saving_throw",
+    "TrapDefinition",
 ]

--- a/dnd/combat.py
+++ b/dnd/combat.py
@@ -1,0 +1,167 @@
+"""Combat utilities for initiative, attack rolls, and saving throws."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .characters import AbilityScores
+from .dungeon import MonsterDefinition
+
+__all__ = [
+    "AttackRollResult",
+    "Combatant",
+    "InitiativeResult",
+    "SavingThrowResult",
+    "ability_modifier",
+    "attack_roll",
+    "roll_d20",
+    "roll_initiative",
+    "saving_throw",
+]
+
+
+def ability_modifier(score: int) -> int:
+    """Return the D&D ability modifier for a given score."""
+
+    return (score - 10) // 2
+
+
+@dataclass(frozen=True)
+class Combatant:
+    """Entity participating in combat, either a character or monster."""
+
+    name: str
+    initiative_bonus: int
+
+    @classmethod
+    def from_scores(cls, name: str, ability_scores: AbilityScores, *, bonus: int = 0) -> "Combatant":
+        dex = ability_scores.values.get("DEX", 10)
+        return cls(name=name, initiative_bonus=ability_modifier(dex) + bonus)
+
+    @classmethod
+    def from_monster(cls, monster: MonsterDefinition, *, bonus: int = 0) -> "Combatant":
+        dex = monster.ability_scores.get("DEX", 10)
+        return cls(name=monster.name, initiative_bonus=ability_modifier(int(dex)) + bonus)
+
+
+@dataclass(frozen=True)
+class InitiativeResult:
+    name: str
+    roll: int
+    total: int
+
+
+def roll_d20(rng: random.Random | None = None) -> int:
+    """Roll a single d20 using the provided RNG or the global generator."""
+
+    generator = rng or random
+    return generator.randint(1, 20)
+
+
+def roll_initiative(
+    participants: Iterable[Combatant],
+    *,
+    rng: random.Random | None = None,
+) -> List[InitiativeResult]:
+    """Roll initiative for the supplied participants."""
+
+    generator = rng or random
+    results: List[InitiativeResult] = []
+    for combatant in participants:
+        roll = roll_d20(generator)
+        total = roll + combatant.initiative_bonus
+        results.append(InitiativeResult(name=combatant.name, roll=roll, total=total))
+    results.sort(key=lambda result: (result.total, result.roll), reverse=True)
+    return results
+
+
+@dataclass(frozen=True)
+class AttackRollResult:
+    total: int
+    roll: int
+    natural: int
+    is_critical_hit: bool
+    is_automatic_miss: bool
+    hits: bool
+
+
+def attack_roll(
+    attacker_bonus: int,
+    target_armor_class: int,
+    *,
+    rng: random.Random | None = None,
+    advantage: bool = False,
+    disadvantage: bool = False,
+) -> AttackRollResult:
+    """Resolve an attack roll against a target's armor class."""
+
+    if advantage and disadvantage:
+        advantage = disadvantage = False
+
+    generator = rng or random
+
+    rolls = [roll_d20(generator)]
+    if advantage:
+        rolls.append(roll_d20(generator))
+    elif disadvantage:
+        rolls.append(roll_d20(generator))
+
+    natural = max(rolls) if advantage else min(rolls) if disadvantage else rolls[0]
+    roll = natural
+    total = roll + attacker_bonus
+
+    is_critical = natural == 20
+    is_automatic_miss = natural == 1
+
+    hits = False
+    if is_critical:
+        hits = True
+    elif not is_automatic_miss:
+        hits = total >= target_armor_class
+
+    return AttackRollResult(
+        total=total,
+        roll=roll,
+        natural=natural,
+        is_critical_hit=is_critical,
+        is_automatic_miss=is_automatic_miss,
+        hits=hits,
+    )
+
+
+@dataclass(frozen=True)
+class SavingThrowResult:
+    total: int
+    roll: int
+    natural: int
+    success: bool
+
+
+def saving_throw(
+    save_bonus: int,
+    dc: int,
+    *,
+    rng: random.Random | None = None,
+    advantage: bool = False,
+    disadvantage: bool = False,
+) -> SavingThrowResult:
+    """Resolve a saving throw against a difficulty class (DC)."""
+
+    if advantage and disadvantage:
+        advantage = disadvantage = False
+
+    generator = rng or random
+    rolls = [roll_d20(generator)]
+    if advantage:
+        rolls.append(roll_d20(generator))
+    elif disadvantage:
+        rolls.append(roll_d20(generator))
+
+    natural = max(rolls) if advantage else min(rolls) if disadvantage else rolls[0]
+    roll = natural
+    total = roll + save_bonus
+    success = total >= dc or natural == 20
+
+    return SavingThrowResult(total=total, roll=roll, natural=natural, success=success)

--- a/dnd/dungeon/__init__.py
+++ b/dnd/dungeon/__init__.py
@@ -1,0 +1,31 @@
+"""Dungeon generation utilities."""
+
+from .generator import (
+    Corridor,
+    Dungeon,
+    DungeonGenerator,
+    EncounterResult,
+    EncounterTable,
+    LootDefinition,
+    MonsterDefinition,
+    Room,
+    RoomTemplate,
+    Theme,
+    ThemeRegistry,
+    TrapDefinition,
+)
+
+__all__ = [
+    "Corridor",
+    "Dungeon",
+    "DungeonGenerator",
+    "EncounterResult",
+    "EncounterTable",
+    "LootDefinition",
+    "MonsterDefinition",
+    "Room",
+    "RoomTemplate",
+    "Theme",
+    "ThemeRegistry",
+    "TrapDefinition",
+]

--- a/dnd/dungeon/generator.py
+++ b/dnd/dungeon/generator.py
@@ -1,0 +1,364 @@
+"""Procedural dungeon generation utilities."""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Mapping, Sequence
+
+__all__ = [
+    "Corridor",
+    "Dungeon",
+    "DungeonGenerator",
+    "EncounterResult",
+    "EncounterTable",
+    "LootDefinition",
+    "MonsterDefinition",
+    "Room",
+    "RoomTemplate",
+    "Theme",
+    "ThemeRegistry",
+    "TrapDefinition",
+]
+
+
+@dataclass(frozen=True)
+class MonsterDefinition:
+    """Static data describing a monster that can appear in encounters."""
+
+    name: str
+    challenge: float
+    armor_class: int
+    hit_points: int
+    attack_bonus: int
+    damage: str
+    ability_scores: Mapping[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TrapDefinition:
+    """Static data describing a trap."""
+
+    name: str
+    description: str
+    saving_throw: Mapping[str, object] | None = None
+    damage: str | None = None
+
+
+@dataclass(frozen=True)
+class LootDefinition:
+    """Static data describing potential loot."""
+
+    name: str
+    rarity: str
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class RoomTemplate:
+    """Template used during room generation."""
+
+    name: str
+    description: str
+    encounter_weights: Mapping[str, int] = field(default_factory=dict)
+    weight: int = 1
+    tags: Sequence[str] = field(default_factory=tuple)
+
+
+class EncounterTable:
+    """Weighted table used to select an encounter type or entry."""
+
+    def __init__(self, entries: Mapping[str, int]) -> None:
+        self._entries: Dict[str, int] = {
+            key: int(value)
+            for key, value in entries.items()
+            if int(value) > 0
+        }
+        if not self._entries:
+            raise ValueError("Encounter table must contain at least one positive weight entry")
+
+    def roll(self, rng: random.Random) -> str:
+        population = list(self._entries.keys())
+        weights = [self._entries[key] for key in population]
+        return rng.choices(population, weights=weights, k=1)[0]
+
+    def entries(self) -> Mapping[str, int]:
+        return dict(self._entries)
+
+
+@dataclass
+class EncounterResult:
+    """Result of generating a single encounter for a room."""
+
+    kind: str
+    summary: str
+    monsters: Sequence[MonsterDefinition] = field(default_factory=tuple)
+    traps: Sequence[TrapDefinition] = field(default_factory=tuple)
+    loot: Sequence[LootDefinition] = field(default_factory=tuple)
+
+
+@dataclass
+class Room:
+    """Generated room with descriptive text and encounter details."""
+
+    id: int
+    name: str
+    description: str
+    encounter: EncounterResult
+    exits: Sequence[int] = field(default_factory=tuple)
+
+
+@dataclass
+class Corridor:
+    """Connection between two rooms."""
+
+    from_room: int
+    to_room: int
+    description: str
+
+
+@dataclass
+class Dungeon:
+    """Generated dungeon consisting of rooms and connecting corridors."""
+
+    name: str
+    seed: int | None
+    theme: "Theme"
+    rooms: Sequence[Room]
+    corridors: Sequence[Corridor]
+
+    def get_room(self, room_id: int) -> Room:
+        for room in self.rooms:
+            if room.id == room_id:
+                return room
+        raise KeyError(room_id)
+
+
+@dataclass(frozen=True)
+class Theme:
+    """Domain model describing a dungeon theme."""
+
+    name: str
+    description: str
+    room_templates: Sequence[RoomTemplate]
+    monsters: Sequence[MonsterDefinition]
+    traps: Sequence[TrapDefinition]
+    loot: Sequence[LootDefinition]
+    encounter_table: EncounterTable
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "Theme":
+        name = str(data["name"])
+        description = str(data.get("description", ""))
+
+        templates: List[RoomTemplate] = []
+        for template_data in data.get("room_templates", []):
+            template = RoomTemplate(
+                name=str(template_data.get("name", "Unknown Room")),
+                description=str(template_data.get("description", "")),
+                encounter_weights={
+                    str(key): int(value)
+                    for key, value in dict(template_data.get("encounter_weights", {})).items()
+                },
+                weight=int(template_data.get("weight", 1)),
+                tags=tuple(template_data.get("tags", [])),
+            )
+            templates.append(template)
+
+        monster_defs: List[MonsterDefinition] = []
+        for monster_data in data.get("monsters", []):
+            monster_defs.append(
+                MonsterDefinition(
+                    name=str(monster_data.get("name", "Mysterious Entity")),
+                    challenge=float(monster_data.get("challenge", 0)),
+                    armor_class=int(monster_data.get("armor_class", 10)),
+                    hit_points=int(monster_data.get("hit_points", 5)),
+                    attack_bonus=int(monster_data.get("attack_bonus", 0)),
+                    damage=str(monster_data.get("damage", "1d6")),
+                    ability_scores=dict(monster_data.get("ability_scores", {})),
+                )
+            )
+
+        trap_defs: List[TrapDefinition] = []
+        for trap_data in data.get("traps", []):
+            trap_defs.append(
+                TrapDefinition(
+                    name=str(trap_data.get("name", "Hidden Trap")),
+                    description=str(trap_data.get("description", "")),
+                    saving_throw=dict(trap_data.get("saving_throw")) if trap_data.get("saving_throw") else None,
+                    damage=(str(trap_data.get("damage")) if trap_data.get("damage") else None),
+                )
+            )
+
+        loot_defs: List[LootDefinition] = []
+        for loot_data in data.get("loot", []):
+            loot_defs.append(
+                LootDefinition(
+                    name=str(loot_data.get("name", "Treasure")),
+                    rarity=str(loot_data.get("rarity", "Common")),
+                    description=(str(loot_data.get("description")) if loot_data.get("description") else None),
+                )
+            )
+
+        encounter_data = dict(data.get("encounters", {}))
+        if not encounter_data:
+            encounter_data = {"combat": 3, "trap": 1, "treasure": 1, "empty": 1}
+
+        encounter_table = EncounterTable(
+            {
+                str(key): int(value)
+                for key, value in encounter_data.items()
+            }
+        )
+
+        return cls(
+            name=name,
+            description=description,
+            room_templates=tuple(templates),
+            monsters=tuple(monster_defs),
+            traps=tuple(trap_defs),
+            loot=tuple(loot_defs),
+            encounter_table=encounter_table,
+        )
+
+    def random_room_template(self, rng: random.Random) -> RoomTemplate:
+        if not self.room_templates:
+            raise ValueError(f"Theme '{self.name}' has no room templates")
+        weights = [max(1, template.weight) for template in self.room_templates]
+        return rng.choices(list(self.room_templates), weights=weights, k=1)[0]
+
+    def random_monsters(self, rng: random.Random, count: int) -> Sequence[MonsterDefinition]:
+        if not self.monsters:
+            return ()
+        return tuple(rng.choices(list(self.monsters), k=count))
+
+    def random_trap(self, rng: random.Random) -> Sequence[TrapDefinition]:
+        if not self.traps:
+            return ()
+        return (rng.choice(list(self.traps)),)
+
+    def random_loot(self, rng: random.Random, count: int = 1) -> Sequence[LootDefinition]:
+        if not self.loot:
+            return ()
+        return tuple(rng.choices(list(self.loot), k=count))
+
+
+class ThemeRegistry:
+    """Registry responsible for loading and providing access to themes."""
+
+    def __init__(self) -> None:
+        self._themes: Dict[str, Theme] = {}
+
+    def register(self, theme: Theme) -> None:
+        self._themes[theme.name.lower()] = theme
+
+    def get(self, name: str) -> Theme:
+        try:
+            return self._themes[name.lower()]
+        except KeyError as exc:
+            raise KeyError(f"Theme '{name}' is not registered") from exc
+
+    def values(self) -> Sequence[Theme]:
+        return tuple(self._themes.values())
+
+    @classmethod
+    def load_from_path(cls, path: Path) -> "ThemeRegistry":
+        registry = cls()
+        if not path.exists():
+            return registry
+        for file_path in sorted(path.glob("*.json")):
+            with file_path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+            theme = Theme.from_dict(data)
+            registry.register(theme)
+        return registry
+
+
+class DungeonGenerator:
+    """Generate dungeons from theme data using deterministic RNG."""
+
+    def __init__(self, theme: Theme, seed: int | None = None) -> None:
+        self.theme = theme
+        self.seed = seed
+        self._rng = random.Random(seed)
+
+    def generate(self, *, room_count: int = 5, name: str | None = None) -> Dungeon:
+        if room_count <= 0:
+            raise ValueError("room_count must be positive")
+
+        rooms: List[Room] = []
+        corridors: List[Corridor] = []
+
+        for index in range(room_count):
+            room = self._generate_room(index)
+            rooms.append(room)
+            if index > 0:
+                corridor = self._generate_corridor(rooms[index - 1], room)
+                corridors.append(corridor)
+
+        dungeon_name = name or f"{self.theme.name} Expedition"
+        return Dungeon(
+            name=dungeon_name,
+            seed=self.seed,
+            theme=self.theme,
+            rooms=tuple(rooms),
+            corridors=tuple(corridors),
+        )
+
+    def _generate_room(self, room_index: int) -> Room:
+        template = self.theme.random_room_template(self._rng)
+        encounter_kind = self._select_encounter_kind(template)
+        encounter = self._build_encounter(encounter_kind)
+
+        description_parts = [template.description]
+        if encounter.summary:
+            description_parts.append(encounter.summary)
+        description = "\n\n".join(part.strip() for part in description_parts if part)
+
+        exits = () if room_index == 0 else (room_index - 1,)
+        return Room(
+            id=room_index,
+            name=template.name,
+            description=description,
+            encounter=encounter,
+            exits=exits,
+        )
+
+    def _generate_corridor(self, from_room: Room, to_room: Room) -> Corridor:
+        length_descriptor = self._rng.choice(["short", "winding", "shadowy", "ancient"])
+        adornment = self._rng.choice(["etched runes", "broken statues", "hanging roots", "flickering torches"])
+        description = f"A {length_descriptor} corridor lined with {adornment}."
+        return Corridor(from_room=from_room.id, to_room=to_room.id, description=description)
+
+    def _select_encounter_kind(self, template: RoomTemplate) -> str:
+        if template.encounter_weights:
+            table = EncounterTable(template.encounter_weights)
+        else:
+            table = self.theme.encounter_table
+        return table.roll(self._rng)
+
+    def _build_encounter(self, kind: str) -> EncounterResult:
+        if kind == "combat":
+            monster_count = self._rng.randint(1, max(1, min(3, len(self.theme.monsters) or 1)))
+            monsters = self.theme.random_monsters(self._rng, monster_count)
+            monster_names = ", ".join(monster.name for monster in monsters)
+            summary = f"Hostile presence detected: {monster_names}."
+            loot = self.theme.random_loot(self._rng, self._rng.randint(0, 2))
+            return EncounterResult(kind=kind, summary=summary, monsters=monsters, loot=loot)
+        if kind == "trap":
+            traps = self.theme.random_trap(self._rng)
+            trap_names = ", ".join(trap.name for trap in traps) if traps else "Subtle hazard"
+            summary = f"A trap awaits: {trap_names}."
+            return EncounterResult(kind=kind, summary=summary, traps=traps)
+        if kind == "treasure":
+            loot = self.theme.random_loot(self._rng, self._rng.randint(1, 3))
+            summary = "Hidden cache discovered." if loot else "Dusty alcoves hold no treasure."
+            return EncounterResult(kind=kind, summary=summary, loot=loot)
+        if kind == "empty":
+            summary = "The chamber is eerily silent, devoid of immediate threats."
+            return EncounterResult(kind=kind, summary=summary)
+        # Fallback: treat as narrative flavor
+        summary = f"An unusual phenomenon tied to {self.theme.name.lower()} energies occurs."
+        return EncounterResult(kind=kind, summary=summary)


### PR DESCRIPTION
## Summary
- add a theme-driven dungeon generator with reusable domain models and encounter tables
- implement combat resolution helpers and export them through the dnd package
- introduce a dungeon cog that loads content packs, exposes /dungeon start, and renders interactive embeds

## Testing
- python -m compileall dnd/combat.py dnd/dungeon/generator.py cogs/dungeon.py

------
https://chatgpt.com/codex/tasks/task_e_68dc96784e0c8329bfef0a89f83da68b