### PR TITLE
Add session manager and persistent dungeon controls

### DIFF
--- a/cogs/dungeon.py
+++ b/cogs/dungeon.py
@@ -1,11 +1,11 @@
-"""Dungeon crawling commands and views."""
+"""Dungeon crawling commands and persistent interaction views."""
 
 from __future__ import annotations
 
 import random
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Iterable, Optional, Tuple
+from typing import Dict, Iterable, Optional
 
 import discord
 from discord import app_commands
@@ -13,6 +13,7 @@ from discord.ext import commands
 
 from dnd.combat import saving_throw
 from dnd.dungeon import Dungeon, DungeonGenerator, Room, Theme, ThemeRegistry
+from dnd.sessions import SessionKey, SessionManager
 
 
 def _default_data_path() -> Path:
@@ -20,16 +21,26 @@ def _default_data_path() -> Path:
 
 
 @dataclass
-class DungeonRun:
+class DungeonSession:
+    """State container for an active dungeon crawl."""
+
     dungeon: Dungeon
+    guild_id: Optional[int]
+    channel_id: int
     current_room: int = 0
-    seed: int | None = None
+    seed: Optional[int] = None
+    party_ids: set[int] = field(default_factory=set)
+    message_id: Optional[int] = None
 
     @property
     def room(self) -> Room:
         return self.dungeon.rooms[self.current_room]
 
-    def travel_description(self) -> str | None:
+    @property
+    def at_final_room(self) -> bool:
+        return self.current_room >= len(self.dungeon.rooms) - 1
+
+    def travel_description(self) -> Optional[str]:
         if self.current_room == 0:
             return None
         for corridor in self.dungeon.corridors:
@@ -39,46 +50,57 @@ class DungeonRun:
 
 
 class DungeonNavigationView(discord.ui.View):
-    def __init__(self, cog: "DungeonCog", run_key: Tuple[int, int]) -> None:
-        super().__init__(timeout=900)
+    """Button controls for navigating dungeon sessions."""
+
+    def __init__(
+        self,
+        cog: "DungeonCog",
+        *,
+        disable_proceed: bool = False,
+        disable_search: bool = False,
+        disable_disarm: bool = False,
+        disable_engage: bool = False,
+    ) -> None:
+        super().__init__(timeout=None)
         self.cog = cog
-        self.run_key = run_key
-        self.message: Optional[discord.Message] = None
+        disabled = {
+            "dungeon:proceed": disable_proceed,
+            "dungeon:search": disable_search,
+            "dungeon:disarm": disable_disarm,
+            "dungeon:engage": disable_engage,
+        }
+        for child in self.children:
+            if isinstance(child, discord.ui.Button) and child.custom_id in disabled:
+                child.disabled = disabled[child.custom_id]
 
-    async def on_timeout(self) -> None:  # noqa: D401 - discord.py hook
-        run = self.cog.active_runs.pop(self.run_key, None)
-        if run is None:
-            return
-        for item in self.children:
-            if isinstance(item, discord.ui.Button):
-                item.disabled = True
-        if self.message:
-            try:
-                await self.message.edit(content="The expedition grows quiet as the magic fades.", view=self)
-            except discord.HTTPException:
-                pass
-
-    @discord.ui.button(label="Proceed", style=discord.ButtonStyle.primary)
+    @discord.ui.button(label="Proceed", style=discord.ButtonStyle.primary, custom_id="dungeon:proceed")
     async def proceed(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:  # noqa: D401
-        await self.cog.handle_proceed(interaction, self)
+        await self.cog.handle_proceed(interaction)
 
-    @discord.ui.button(label="Search", style=discord.ButtonStyle.secondary)
+    @discord.ui.button(label="Search", style=discord.ButtonStyle.secondary, custom_id="dungeon:search")
     async def search(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:  # noqa: D401
         await self.cog.handle_search(interaction)
 
-    @discord.ui.button(label="Disarm Trap", style=discord.ButtonStyle.danger)
+    @discord.ui.button(label="Disarm Trap", style=discord.ButtonStyle.danger, custom_id="dungeon:disarm")
     async def disarm(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:  # noqa: D401
         await self.cog.handle_disarm(interaction)
+
+    @discord.ui.button(label="Engage", style=discord.ButtonStyle.success, custom_id="dungeon:engage")
+    async def engage(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:  # noqa: D401
+        await self.cog.handle_engage(interaction)
 
 
 class DungeonCog(commands.Cog):
     """Slash commands to generate and explore procedural dungeons."""
 
+    dungeon_group = app_commands.Group(name="dungeon", description="Procedural dungeon exploration")
+
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         data_path = _default_data_path()
         self.theme_registry = ThemeRegistry.load_from_path(data_path)
-        self.active_runs: Dict[Tuple[int, int], DungeonRun] = {}
+        self.sessions: SessionManager[DungeonSession] = SessionManager()
+        self.guild_themes: Dict[int, str] = {}
 
     def cog_unload(self) -> None:  # noqa: D401 - discord.py hook
         try:
@@ -86,23 +108,45 @@ class DungeonCog(commands.Cog):
         except (app_commands.CommandTreeException, KeyError):
             pass
 
-    # ---- Command helpers -------------------------------------------------
-    def _run_key(self, interaction: discord.Interaction) -> Tuple[int, int]:
-        guild_id = interaction.guild_id or interaction.user.id
-        channel_id = interaction.channel_id or interaction.user.id
-        return (guild_id, channel_id)
+    # ------------------------------------------------------------------
+    def _session_key(self, guild_id: Optional[int], channel_id: Optional[int]) -> SessionKey:
+        return SessionManager.make_key(guild_id, channel_id)
 
-    def _resolve_theme(self, name: str | None) -> Theme:
-        if name:
-            return self.theme_registry.get(name)
+    def _resolve_theme(self, theme_name: Optional[str], guild_id: Optional[int]) -> Theme:
+        if theme_name:
+            return self.theme_registry.get(theme_name)
+        if guild_id is not None:
+            default = self.guild_themes.get(guild_id)
+            if default:
+                return self.theme_registry.get(default)
         try:
             return next(iter(self.theme_registry.values()))
         except StopIteration as exc:
             raise RuntimeError("No dungeon themes are available") from exc
 
-    def _build_room_embed(self, run: DungeonRun) -> discord.Embed:
-        room = run.room
-        dungeon = run.dungeon
+    def _party_display(self, interaction: discord.Interaction, session: DungeonSession) -> str:
+        if not session.party_ids:
+            return "No adventurers yet."
+
+        names: list[str] = []
+        for user_id in sorted(session.party_ids):
+            name: Optional[str] = None
+            if interaction.guild:
+                member = interaction.guild.get_member(user_id)
+                if member is not None:
+                    name = member.display_name
+            if name is None:
+                user = self.bot.get_user(user_id)
+                if user is not None:
+                    name = user.display_name
+            if name is None:
+                name = f"<@{user_id}>"
+            names.append(name)
+        return "\n".join(f"• {name}" for name in names)
+
+    def _build_room_embed(self, interaction: discord.Interaction, session: DungeonSession) -> discord.Embed:
+        room = session.room
+        dungeon = session.dungeon
         embed = discord.Embed(
             title=f"{dungeon.name} — Room {room.id + 1}: {room.name}",
             description=room.description,
@@ -130,21 +174,63 @@ class DungeonCog(commands.Cog):
             loot_lines = [f"• {item.name} ({item.rarity})" for item in room.encounter.loot]
             embed.add_field(name="Loot", value="\n".join(loot_lines), inline=False)
 
-        travel = run.travel_description()
+        travel = session.travel_description()
         if travel:
             embed.add_field(name="Approach", value=travel, inline=False)
 
+        embed.add_field(name="Party", value=self._party_display(interaction, session), inline=False)
+
+        actions: list[str] = []
+        if not session.at_final_room:
+            actions.append("Proceed deeper into the dungeon.")
+        if room.encounter.monsters:
+            actions.append("Engage the monsters in combat.")
+        if room.encounter.traps:
+            actions.append("Attempt to disarm the traps.")
+        if room.encounter.loot:
+            actions.append("Search the chamber for hidden loot.")
+        if not actions:
+            actions.append("Take a moment to catch your breath.")
+        embed.add_field(name="Available Actions", value="\n".join(f"• {line}" for line in actions), inline=False)
+
         footer_parts = [f"Theme: {dungeon.theme.name}"]
-        if dungeon.seed is not None:
-            footer_parts.append(f"Seed: {dungeon.seed}")
+        if session.seed is not None:
+            footer_parts.append(f"Seed: {session.seed}")
         embed.set_footer(text=" • ".join(footer_parts))
         return embed
 
-    # ---- Slash commands --------------------------------------------------
-    dungeon_group = app_commands.Group(name="dungeon", description="Procedural dungeon exploration")
+    def _build_navigation_view(self, session: DungeonSession) -> DungeonNavigationView:
+        room = session.room
+        return DungeonNavigationView(
+            self,
+            disable_proceed=session.at_final_room,
+            disable_search=not bool(room.encounter.loot),
+            disable_disarm=not bool(room.encounter.traps),
+            disable_engage=not bool(room.encounter.monsters),
+        )
 
+    async def _refresh_session_message(self, interaction: discord.Interaction, session: DungeonSession) -> None:
+        if session.message_id is None:
+            return
+        embed = self._build_room_embed(interaction, session)
+        view = self._build_navigation_view(session)
+        try:
+            await interaction.followup.edit_message(
+                message_id=session.message_id,
+                embed=embed,
+                view=view,
+            )
+            self.bot.add_view(view, message_id=session.message_id)
+        except discord.HTTPException:
+            pass
+
+    # ---- Slash commands --------------------------------------------------
     @dungeon_group.command(name="start", description="Generate a themed dungeon and begin exploring.")
-    @app_commands.describe(theme="Name of the dungeon theme to use", rooms="Number of rooms to generate", seed="Optional RNG seed")
+    @app_commands.describe(
+        theme="Name of the dungeon theme to use",
+        rooms="Number of rooms to generate",
+        seed="Optional RNG seed",
+    )
     async def start(
         self,
         interaction: discord.Interaction,
@@ -160,11 +246,23 @@ class DungeonCog(commands.Cog):
             return
 
         try:
-            theme_obj = self._resolve_theme(theme)
+            theme_obj = self._resolve_theme(theme, interaction.guild_id)
         except KeyError:
             available = ", ".join(sorted(t.name for t in self.theme_registry.values()))
             await interaction.response.send_message(
                 f"Unknown theme '{theme}'. Available themes: {available}.",
+                ephemeral=True,
+            )
+            return
+        except RuntimeError as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+
+        key = self._session_key(interaction.guild_id, interaction.channel_id)
+        existing = await self.sessions.get(key)
+        if existing is not None:
+            await interaction.response.send_message(
+                "A party is already exploring this channel. Use /dungeon reset to start over.",
                 ephemeral=True,
             )
             return
@@ -173,15 +271,22 @@ class DungeonCog(commands.Cog):
             seed = random.randint(0, 999999)
         generator = DungeonGenerator(theme_obj, seed=seed)
         dungeon = generator.generate(room_count=int(rooms))
-        run = DungeonRun(dungeon=dungeon, seed=seed)
-        key = self._run_key(interaction)
-        self.active_runs[key] = run
+        session = DungeonSession(
+            dungeon=dungeon,
+            guild_id=interaction.guild_id,
+            channel_id=interaction.channel_id or interaction.user.id,
+            seed=seed,
+        )
+        session.party_ids.add(interaction.user.id)
+        await self.sessions.set(key, session)
 
-        embed = self._build_room_embed(run)
-        view = DungeonNavigationView(self, key)
-
+        embed = self._build_room_embed(interaction, session)
+        view = self._build_navigation_view(session)
         await interaction.response.send_message(embed=embed, view=view)
-        view.message = await interaction.original_response()
+        message = await interaction.original_response()
+        session = await self.sessions.update(key, lambda run: setattr(run, "message_id", message.id))
+        if session is not None:
+            self.bot.add_view(view, message_id=message.id)
 
     @start.autocomplete("theme")
     async def theme_autocomplete(
@@ -191,68 +296,152 @@ class DungeonCog(commands.Cog):
         filtered = [name for name in names if current.lower() in name.lower()][:25]
         return [app_commands.Choice(name=name, value=name) for name in filtered]
 
-    # ---- Interaction handlers -------------------------------------------
-    async def handle_proceed(self, interaction: discord.Interaction, view: DungeonNavigationView) -> None:
-        key = self._run_key(interaction)
-        run = self.active_runs.get(key)
-        if run is None:
-            await interaction.response.send_message("No active dungeon for this party.", ephemeral=True)
+    @dungeon_group.command(name="reset", description="Reset the active dungeon session in this channel.")
+    @app_commands.checks.has_permissions(manage_guild=True)
+    async def reset(self, interaction: discord.Interaction) -> None:
+        key = self._session_key(interaction.guild_id, interaction.channel_id)
+        session = await self.sessions.pop(key)
+        if session is None:
+            await interaction.response.send_message("There is no active dungeon in this channel.", ephemeral=True)
             return
 
-        if run.current_room >= len(run.dungeon.rooms) - 1:
-            for item in view.children:
-                if isinstance(item, discord.ui.Button):
-                    item.disabled = True
-            self.active_runs.pop(key, None)
-            await interaction.response.edit_message(view=view)
-            await interaction.followup.send(
-                "The party has already reached the end of this dungeon!",
+        await interaction.response.defer(ephemeral=True)
+        if session.message_id is not None:
+            try:
+                await interaction.followup.edit_message(message_id=session.message_id, view=None)
+            except discord.HTTPException:
+                pass
+        await interaction.followup.send("The dungeon session has been reset.", ephemeral=True)
+
+    @dungeon_group.command(name="theme", description="Configure the default dungeon theme for this guild.")
+    @app_commands.describe(name="Theme name to use as default", clear="Clear the configured default theme")
+    @app_commands.checks.has_permissions(manage_guild=True)
+    async def configure_theme(
+        self,
+        interaction: discord.Interaction,
+        name: Optional[str] = None,
+        clear: bool = False,
+    ) -> None:
+        if interaction.guild_id is None:
+            await interaction.response.send_message(
+                "Default themes can only be configured inside a guild.",
                 ephemeral=True,
             )
             return
 
-        run.current_room += 1
-        embed = self._build_room_embed(run)
-        new_view = DungeonNavigationView(self, key)
-        new_view.message = interaction.message
+        if clear:
+            self.guild_themes.pop(interaction.guild_id, None)
+            await interaction.response.send_message("Cleared the default dungeon theme.", ephemeral=True)
+            return
 
-        await interaction.response.edit_message(embed=embed, view=new_view)
+        if name is None:
+            await interaction.response.send_message(
+                "Please provide a theme name or enable the clear option.",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            theme = self.theme_registry.get(name)
+        except KeyError:
+            available = ", ".join(sorted(t.name for t in self.theme_registry.values())) or "None"
+            await interaction.response.send_message(
+                f"Unknown theme '{name}'. Available themes: {available}.",
+                ephemeral=True,
+            )
+            return
+
+        self.guild_themes[interaction.guild_id] = theme.name
+        await interaction.response.send_message(
+            f"Default dungeon theme set to {theme.name}.",
+            ephemeral=True,
+        )
+
+    # ---- Interaction handlers -------------------------------------------
+    async def handle_proceed(self, interaction: discord.Interaction) -> None:
+        key = self._session_key(interaction.guild_id, interaction.channel_id)
+        session = await self.sessions.get(key)
+        if session is None:
+            await interaction.response.send_message("No active dungeon for this party.", ephemeral=True)
+            return
+
+        await interaction.response.defer()
+        advanced = False
+        reached_final = session.at_final_room
+
+        def mutate(run: DungeonSession) -> None:
+            nonlocal advanced, reached_final
+            run.party_ids.add(interaction.user.id)
+            if run.at_final_room:
+                reached_final = True
+                return
+            run.current_room += 1
+            advanced = True
+            reached_final = run.at_final_room
+
+        session = await self.sessions.update(key, mutate)
+        if session is None:
+            await interaction.followup.send("No active dungeon for this party.", ephemeral=True)
+            return
+
+        await self._refresh_session_message(interaction, session)
+        if advanced:
+            await interaction.followup.send("You press onward into the next chamber...", ephemeral=True)
+        elif reached_final:
+            await interaction.followup.send(
+                "The party has already reached the end of this dungeon!",
+                ephemeral=True,
+            )
+        else:
+            await interaction.followup.send(
+                "Unable to proceed right now. Try again in a moment.",
+                ephemeral=True,
+            )
 
     async def handle_search(self, interaction: discord.Interaction) -> None:
-        key = self._run_key(interaction)
-        run = self.active_runs.get(key)
-        if run is None:
+        key = self._session_key(interaction.guild_id, interaction.channel_id)
+        session = await self.sessions.update(key, lambda run: run.party_ids.add(interaction.user.id))
+        if session is None:
             await interaction.response.send_message("No active dungeon to search.", ephemeral=True)
             return
 
-        loot = run.room.encounter.loot
+        await interaction.response.defer(ephemeral=True)
+        await self._refresh_session_message(interaction, session)
+        loot = session.room.encounter.loot
         if not loot:
-            await interaction.response.send_message("You find nothing of value after a thorough search.", ephemeral=True)
+            await interaction.followup.send(
+                "You find nothing of value after a thorough search.",
+                ephemeral=True,
+            )
             return
 
         lines = [f"• {item.name} ({item.rarity})" for item in loot]
-        await interaction.response.send_message(
+        await interaction.followup.send(
             "You uncover hidden items:\n" + "\n".join(lines),
             ephemeral=True,
         )
 
     async def handle_disarm(self, interaction: discord.Interaction) -> None:
-        key = self._run_key(interaction)
-        run = self.active_runs.get(key)
-        if run is None:
+        key = self._session_key(interaction.guild_id, interaction.channel_id)
+        session = await self.sessions.update(key, lambda run: run.party_ids.add(interaction.user.id))
+        if session is None:
             await interaction.response.send_message("No traps challenge the party right now.", ephemeral=True)
             return
 
-        traps = run.room.encounter.traps
+        await interaction.response.defer(ephemeral=True)
+        await self._refresh_session_message(interaction, session)
+        traps = session.room.encounter.traps
         if not traps:
-            await interaction.response.send_message("There are no traps present in this room.", ephemeral=True)
+            await interaction.followup.send(
+                "There are no traps present in this room.",
+                ephemeral=True,
+            )
             return
 
         trap = traps[0]
         dc = int(trap.saving_throw.get("dc", 15)) if trap.saving_throw else 15
         ability = str(trap.saving_throw.get("ability", "DEX")) if trap.saving_throw else "DEX"
 
-        # Assume a skilled rogue with a +5 bonus attempts the disarm for quick resolution.
         result = saving_throw(save_bonus=5, dc=dc)
         if result.success:
             message = (
@@ -264,7 +453,32 @@ class DungeonCog(commands.Cog):
                 f"The {trap.name} resists your efforts (Roll {result.total}, DC {dc} {ability} save). "
                 "Perhaps try another approach."
             )
-        await interaction.response.send_message(message, ephemeral=True)
+        await interaction.followup.send(message, ephemeral=True)
+
+    async def handle_engage(self, interaction: discord.Interaction) -> None:
+        key = self._session_key(interaction.guild_id, interaction.channel_id)
+        session = await self.sessions.update(key, lambda run: run.party_ids.add(interaction.user.id))
+        if session is None:
+            await interaction.response.send_message("No foes stand before the party right now.", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        await self._refresh_session_message(interaction, session)
+        monsters = session.room.encounter.monsters
+        if not monsters:
+            await interaction.followup.send(
+                "The room is eerily quiet—there is nothing to fight here.",
+                ephemeral=True,
+            )
+            return
+
+        foe = random.choice(monsters)
+        attack_roll = random.randint(1, 20) + 5
+        if attack_roll >= foe.armor_class:
+            message = f"Your strike hits {foe.name}! (Attack {attack_roll} vs AC {foe.armor_class})"
+        else:
+            message = f"Your blow glances off {foe.name}'s defenses. (Attack {attack_roll} vs AC {foe.armor_class})"
+        await interaction.followup.send(message, ephemeral=True)
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/dnd/sessions.py
+++ b/dnd/sessions.py
@@ -1,0 +1,91 @@
+"""Session management utilities for coordinating dungeon parties."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Callable, Dict, Generic, Optional, Tuple, TypeVar
+
+SessionKey = Tuple[Optional[int], int]
+
+T = TypeVar("T")
+
+
+class SessionManager(Generic[T]):
+    """Track active sessions keyed by guild and channel identifiers.
+
+    The manager serialises access to the internal session mapping via an
+    :class:`asyncio.Lock`. This prevents race conditions when multiple
+    interactions try to mutate the same session concurrently (e.g. when
+    several buttons are pressed at the same time).
+    """
+
+    __slots__ = ("_sessions", "_lock")
+
+    def __init__(self) -> None:
+        self._sessions: Dict[SessionKey, T] = {}
+        self._lock = asyncio.Lock()
+
+    @staticmethod
+    def make_key(guild_id: Optional[int], channel_id: Optional[int]) -> SessionKey:
+        """Build a stable key for a guild/channel pair."""
+
+        if channel_id is None:
+            raise ValueError("channel_id is required to build a session key")
+        return (guild_id, channel_id)
+
+    async def get(self, key: SessionKey) -> Optional[T]:
+        """Return the session associated with ``key`` if it exists."""
+
+        async with self._lock:
+            return self._sessions.get(key)
+
+    async def set(self, key: SessionKey, session: T) -> T:
+        """Store or replace the ``session`` value for ``key``."""
+
+        async with self._lock:
+            self._sessions[key] = session
+            return session
+
+    async def pop(self, key: SessionKey) -> Optional[T]:
+        """Remove and return the session for ``key`` if it exists."""
+
+        async with self._lock:
+            return self._sessions.pop(key, None)
+
+    async def clear_guild(self, guild_id: int) -> int:
+        """Remove all sessions associated with ``guild_id``.
+
+        Returns the number of sessions removed.
+        """
+
+        async with self._lock:
+            to_remove = [key for key in self._sessions if key[0] == guild_id]
+            for key in to_remove:
+                del self._sessions[key]
+            return len(to_remove)
+
+    async def update(self, key: SessionKey, mutator: Callable[[T], None]) -> Optional[T]:
+        """Apply ``mutator`` to the session mapped to ``key``.
+
+        The callable ``mutator`` is invoked while holding the internal lock and
+        must therefore be synchronous.
+        """
+
+        async with self._lock:
+            session = self._sessions.get(key)
+            if session is None:
+                return None
+            mutator(session)
+            return session
+
+    async def keys(self) -> Tuple[SessionKey, ...]:
+        """Return a snapshot of the active session keys."""
+
+        async with self._lock:
+            return tuple(self._sessions.keys())
+
+    @property
+    def lock(self) -> asyncio.Lock:
+        """Expose the internal lock for complex compound operations."""
+
+        return self._lock


### PR DESCRIPTION
## Summary
- add a reusable asyncio-locked SessionManager for coordinating dungeon sessions
- refactor the dungeon cog to use the manager, persistent button views, and richer room embeds
- add new admin configuration commands and combat interaction handling for dungeon runs

## Testing
- python -m compileall dnd cogs

------
https://chatgpt.com/codex/tasks/task_e_68dc98be3e8483299842facb39191c3d