### PR TITLE
Handle duplicate dungeon slash command registration

### DIFF
--- a/cogs/dungeon.py
+++ b/cogs/dungeon.py
@@ -534,4 +534,7 @@ class DungeonCog(commands.Cog):
 async def setup(bot: commands.Bot) -> None:
     cog = DungeonCog(bot)
     await bot.add_cog(cog)
+    existing = bot.tree.get_command(cog.dungeon_group.name, type=cog.dungeon_group.type)
+    if existing is not None:
+        bot.tree.remove_command(cog.dungeon_group.name, type=cog.dungeon_group.type)
     bot.tree.add_command(cog.dungeon_group)


### PR DESCRIPTION
## Summary
- prevent duplicate registration of the dungeon slash command group by removing any existing command before adding it again

## Testing
- python -m compileall cogs/dungeon.py

------
https://chatgpt.com/codex/tasks/task_e_68dca3513bd083298f9ee3e057747846