### PR TITLE
Fix dungeon command registration for discord.py 2.4

### DIFF
--- a/cogs/dungeon.py
+++ b/cogs/dungeon.py
@@ -111,7 +111,10 @@ class DungeonCog(commands.Cog):
 
     def cog_unload(self) -> None:  # noqa: D401 - discord.py hook
         try:
-            self.bot.tree.remove_command(self.dungeon_group.name, type=self.dungeon_group.type)
+            self.bot.tree.remove_command(
+                self.dungeon_group.name,
+                type=app_commands.CommandType.chat_input,
+            )
         except (app_commands.CommandTreeException, KeyError):
             pass
 
@@ -534,7 +537,13 @@ class DungeonCog(commands.Cog):
 async def setup(bot: commands.Bot) -> None:
     cog = DungeonCog(bot)
     await bot.add_cog(cog)
-    existing = bot.tree.get_command(cog.dungeon_group.name, type=cog.dungeon_group.type)
+    existing = bot.tree.get_command(
+        cog.dungeon_group.name,
+        type=app_commands.CommandType.chat_input,
+    )
     if existing is not None:
-        bot.tree.remove_command(cog.dungeon_group.name, type=cog.dungeon_group.type)
+        bot.tree.remove_command(
+            cog.dungeon_group.name,
+            type=app_commands.CommandType.chat_input,
+        )
     bot.tree.add_command(cog.dungeon_group)


### PR DESCRIPTION
## Summary
- ensure the dungeon slash command group is registered and removed using the chat input command type to avoid attribute errors on newer discord.py versions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dca4aa40c48329bd78f9143e47a98b