### PR TITLE
Sync slash commands during bot setup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -56,6 +56,8 @@ class SlashCommandBot(commands.Bot):
     async def setup_hook(self) -> None:  # type: ignore[override]
         await load_cogs(self, self._cogs_path)
         logging.info("All cogs loaded")
+        synced_commands = await self.tree.sync()
+        logging.info("Synced %s application commands", len(synced_commands))
 
     def add_command(  # type: ignore[override]
         self, command: commands.Command, *args, **kwargs


### PR DESCRIPTION
## Summary
- sync application commands with Discord after loading cogs so they are registered on startup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcaa63c714832992753a0988ca4482