### PR TITLE
Fix loading last_room_count in dungeon metadata deserialization

### DIFF
--- a/dnd/dungeon/state.py
+++ b/dnd/dungeon/state.py
@@ -77,6 +77,7 @@ class GuildSessionMetadata:
         last_seed = raw.get("last_seed")
         last_difficulty = raw.get("last_difficulty")
         last_name = raw.get("last_name")
+        last_room_count = raw.get("last_room_count")
         dungeons: Dict[str, StoredDungeon] = {}
         raw_dungeons = raw.get("dungeons")
         if isinstance(raw_dungeons, Mapping):


### PR DESCRIPTION
## Summary
- ensure `GuildSessionMetadata.from_dict` reads `last_room_count` from the stored payload before validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcd2eb79b48329aa2db43753ec13b7