### PR TITLE
Add SRD-driven character creation flow

### DIFF
--- a/cogs/character_creation.py
+++ b/cogs/character_creation.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import random
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Mapping, Optional, Sequence
 
 import discord
 from discord import app_commands
@@ -12,160 +12,445 @@ from discord.ext import commands
 
 from dnd import (
     ABILITY_NAMES,
+    AVAILABLE_BACKGROUNDS,
     AVAILABLE_CLASSES,
     AVAILABLE_RACES,
     AbilityScores,
     Character,
     CharacterRepository,
 )
+from dnd.characters import EquipmentChoice, EquipmentChoiceOption
+
+LANGUAGE_OPTIONS: tuple[str, ...] = (
+    "Common",
+    "Dwarvish",
+    "Elvish",
+    "Giant",
+    "Gnomish",
+    "Goblin",
+    "Halfling",
+    "Orc",
+    "Draconic",
+)
 
 
-class RaceSelect(discord.ui.Select[discord.ui.View]):
-    def __init__(self, view: "CharacterCreationView") -> None:
-        self._creation_view = view
-        options = [
-            discord.SelectOption(
-                label=race.name,
-                description=race.description[:100],
-            )
-            for race in AVAILABLE_RACES.values()
-        ]
-        super().__init__(
-            placeholder="Choose a race",
-            min_values=1,
-            max_values=1,
-            options=options,
+class CreationStateError(ValueError):
+    """Raised when invalid state transitions occur during creation."""
+
+
+@dataclass
+class CreationState:
+    """Pure data container describing a user's creation progress."""
+
+    method: str = "standard_array"
+    base_scores: AbilityScores | None = None
+    ability_scores: AbilityScores | None = None
+    race_key: str | None = None
+    race_languages: tuple[str, ...] = field(default_factory=tuple)
+    class_key: str | None = None
+    class_skill_choices: tuple[str, ...] = field(default_factory=tuple)
+    background_key: str | None = None
+    background_languages: tuple[str, ...] = field(default_factory=tuple)
+    equipment_choices: Dict[str, tuple[str, ...]] = field(default_factory=dict)
+    racial_bonuses: Dict[str, int] = field(default_factory=dict)
+
+    def set_method(self, method: str) -> None:
+        method = method.lower()
+        if method not in {"standard_array", "point_buy"}:
+            raise CreationStateError("Unsupported ability assignment method")
+        if method != self.method:
+            self.method = method
+            self.base_scores = None
+            self.ability_scores = None
+            self.racial_bonuses = {}
+
+    def assign_scores(self, assignments: Mapping[str, int], *, method: str | None = None) -> AbilityScores:
+        if method:
+            self.set_method(method)
+        if not self.method:
+            raise CreationStateError("Ability assignment method must be selected before assigning scores")
+        base = AbilityScores.from_assignments(assignments, method=self.method)
+        self.base_scores = base
+        if self.race_key:
+            self.apply_race(self.race_key, languages=self.race_languages)
+        else:
+            self.ability_scores = base
+            self.racial_bonuses = {}
+        return base
+
+    def _require_base_scores(self) -> AbilityScores:
+        if not self.base_scores:
+            raise CreationStateError("Assign ability scores before selecting a race")
+        return self.base_scores
+
+    def apply_race(self, race_key: str, *, languages: Sequence[str] | None = None) -> None:
+        base_scores = self._require_base_scores()
+        key = race_key.lower()
+        if key not in AVAILABLE_RACES:
+            raise CreationStateError("Unknown race selection")
+        race = AVAILABLE_RACES[key]
+        if languages is None:
+            languages = self.race_languages
+        required = race.languages.choices
+        validated = self._validate_languages(
+            languages,
+            required,
+            label=f"race {race.name}",
+            allow_empty=True,
         )
+        self.race_languages = validated
+        bonuses: Dict[str, int] = {}
+        for bonus in race.ability_bonuses:
+            bonuses[bonus.ability] = bonuses.get(bonus.ability, 0) + bonus.bonus
+        self.racial_bonuses = bonuses
+        self.ability_scores = base_scores.with_bonuses(bonuses)
+        self.race_key = key
 
-    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
-        self._creation_view.selected_race = self.values[0]
-        self._creation_view.handle_step_progression()
-        await self._creation_view.refresh(interaction)
+    def set_race_languages(self, languages: Sequence[str]) -> None:
+        if not self.race_key:
+            raise CreationStateError("Select a race before choosing languages")
+        race = AVAILABLE_RACES[self.race_key]
+        validated = self._validate_languages(languages, race.languages.choices, label=f"race {race.name}")
+        self.race_languages = validated
+        if self.base_scores:
+            self.apply_race(self.race_key, languages=validated)
 
+    def set_class(self, class_key: str) -> None:
+        key = class_key.lower()
+        if key not in AVAILABLE_CLASSES:
+            raise CreationStateError("Unknown class selection")
+        self.class_key = key
+        self.class_skill_choices = tuple()
+        self.equipment_choices = {}
 
-class ClassSelect(discord.ui.Select[discord.ui.View]):
-    def __init__(self, view: "CharacterCreationView") -> None:
-        self._creation_view = view
-        options = [
-            discord.SelectOption(
-                label=character_class.name,
-                description=f"Primary: {character_class.primary_ability}",
-            )
-            for character_class in AVAILABLE_CLASSES.values()
-        ]
-        super().__init__(
-            placeholder="Choose a class",
-            min_values=1,
-            max_values=1,
-            options=options,
-        )
-
-    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
-        self._creation_view.selected_class = self.values[0]
-        self._creation_view.handle_step_progression()
-        await self._creation_view.refresh(interaction)
-
-
-class RerollAbilityScoresButton(discord.ui.Button[discord.ui.View]):
-    def __init__(self, view: "CharacterCreationView") -> None:
-        super().__init__(label="Reroll ability scores", style=discord.ButtonStyle.primary, disabled=True)
-        self._creation_view = view
-
-    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
-        self._creation_view.roll_random_ability_scores()
-        await interaction.response.edit_message(
-            embed=self._creation_view.build_embed(),
-            view=self._creation_view,
-        )
-
-
-def _roll_4d6_drop_lowest() -> int:
-    dice = sorted(random.randint(1, 6) for _ in range(4))
-    return sum(dice[1:])
-
-
-class ResetButton(discord.ui.Button[discord.ui.View]):
-    def __init__(self, view: "CharacterCreationView") -> None:
-        super().__init__(label="Reset choices", style=discord.ButtonStyle.secondary)
-        self._creation_view = view
-
-    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
-        self._creation_view.reset()
-        await interaction.response.edit_message(
-            embed=self._creation_view.build_embed(),
-            view=self._creation_view,
-        )
-
-
-class ConfirmButton(discord.ui.Button[discord.ui.View]):
-    def __init__(self, view: "CharacterCreationView") -> None:
-        super().__init__(label="Confirm character", style=discord.ButtonStyle.success, disabled=True)
-        self._creation_view = view
-
-    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
-        await interaction.response.defer(ephemeral=True, thinking=True)
-
-        view = self._creation_view
-        if not interaction.guild:
-            await interaction.followup.send("This command can only be used in a server.", ephemeral=True)
+    def set_class_skills(self, skills: Sequence[str]) -> None:
+        if not self.class_key:
+            raise CreationStateError("Select a class before choosing skills")
+        character_class = AVAILABLE_CLASSES[self.class_key]
+        required = character_class.skill_proficiency_options.count
+        options = set(character_class.skill_proficiency_options.options)
+        if required == 0:
+            self.class_skill_choices = tuple()
             return
-
-        if await view.repository.exists(interaction.guild.id, interaction.user.id):
-            await interaction.followup.send(
-                "You already have a character saved. Reset first if you want to recreate it.",
-                ephemeral=True,
+        cleaned = tuple(dict.fromkeys(str(skill) for skill in skills))
+        if len(cleaned) != required:
+            raise CreationStateError(
+                f"Select exactly {required} skill proficiency{'ies' if required != 1 else ''}"
             )
-            return
+        if not set(cleaned).issubset(options):
+            raise CreationStateError("Invalid skill selection for class")
+        self.class_skill_choices = cleaned
 
-        ability_scores = view.ability_scores
-        if not (view.selected_race and view.selected_class and ability_scores):
-            await interaction.followup.send(
-                "Please complete all steps before confirming.",
-                ephemeral=True,
-            )
-            return
-
-        race = AVAILABLE_RACES[view.selected_race]
-        character_class = AVAILABLE_CLASSES[view.selected_class]
-        character = Character(
-            guild_id=interaction.guild.id,
-            user_id=interaction.user.id,
-            race=race,
-            character_class=character_class,
-            ability_scores=ability_scores,
-            name=f"{interaction.user.display_name}'s Adventurer",
+    def set_background(self, background_key: str, *, languages: Sequence[str] | None = None) -> None:
+        key = background_key.lower()
+        if key not in AVAILABLE_BACKGROUNDS:
+            raise CreationStateError("Unknown background selection")
+        background = AVAILABLE_BACKGROUNDS[key]
+        validated = self._validate_languages(
+            languages or self.background_languages,
+            background.language_choices,
+            label=f"background {background.name}",
+            allow_empty=True,
         )
-        await view.repository.save(character)
+        self.background_key = key
+        self.background_languages = validated
 
-        confirmation_embed = view.build_confirmation_embed(interaction.user, character)
-        if view.message:
-            await view.message.edit(embed=confirmation_embed, view=None)
-        await interaction.followup.send("Character saved successfully!", ephemeral=True)
-        view.stop()
+    def set_background_languages(self, languages: Sequence[str]) -> None:
+        if not self.background_key:
+            raise CreationStateError("Select a background before choosing languages")
+        background = AVAILABLE_BACKGROUNDS[self.background_key]
+        validated = self._validate_languages(
+            languages,
+            background.language_choices,
+            label=f"background {background.name}",
+        )
+        self.background_languages = validated
+
+    def set_equipment_choice(self, choice_key: str, option_keys: Sequence[str]) -> None:
+        if not self.class_key:
+            raise CreationStateError("Select a class before choosing equipment")
+        character_class = AVAILABLE_CLASSES[self.class_key]
+        choice = self._find_equipment_choice(character_class.equipment_choices, choice_key)
+        cleaned = tuple(dict.fromkeys(str(option).lower() for option in option_keys))
+        if len(cleaned) != choice.choose:
+            raise CreationStateError(
+                f"Select exactly {choice.choose} option{'s' if choice.choose != 1 else ''} for this equipment choice"
+            )
+        valid_keys = {option.key for option in choice.options}
+        if not set(cleaned).issubset(valid_keys):
+            raise CreationStateError("Invalid equipment selection")
+        self.equipment_choices[choice.key] = cleaned
+
+    def _find_equipment_choice(
+        self, choices: Sequence[EquipmentChoice], choice_key: str
+    ) -> EquipmentChoice:
+        key = choice_key.lower()
+        for choice in choices:
+            if choice.key == key:
+                return choice
+        raise CreationStateError("Unknown equipment choice")
+
+    # -- validation helpers -------------------------------------------------
+    def _validate_languages(
+        self,
+        languages: Sequence[str] | None,
+        required: int,
+        *,
+        label: str,
+        allow_empty: bool = False,
+    ) -> tuple[str, ...]:
+        if required == 0:
+            return tuple()
+        if languages is None:
+            if allow_empty:
+                return tuple()
+            raise CreationStateError(f"Provide {required} language choice{'s' if required != 1 else ''} for {label}")
+        cleaned = tuple(dict.fromkeys(lang.strip().title() for lang in languages if lang.strip()))
+        if len(cleaned) != required:
+            if allow_empty and not cleaned:
+                return tuple()
+            raise CreationStateError(
+                f"Select exactly {required} language choice{'s' if required != 1 else ''} for {label}"
+            )
+        invalid = [language for language in cleaned if language not in LANGUAGE_OPTIONS]
+        if invalid:
+            raise CreationStateError(
+                "Unsupported language selections: " + ", ".join(sorted(set(invalid)))
+            )
+        return cleaned
+
+    # -- step helpers -------------------------------------------------------
+    def needs_ability_scores(self) -> bool:
+        return self.base_scores is None
+
+    def needs_race(self) -> bool:
+        return self.race_key is None
+
+    def needs_race_languages(self) -> bool:
+        if not self.race_key:
+            return False
+        race = AVAILABLE_RACES[self.race_key]
+        return race.languages.choices > 0 and len(self.race_languages) != race.languages.choices
+
+    def needs_class(self) -> bool:
+        return self.class_key is None
+
+    def needs_class_skills(self) -> bool:
+        if not self.class_key:
+            return False
+        required = AVAILABLE_CLASSES[self.class_key].skill_proficiency_options.count
+        return required > 0 and len(self.class_skill_choices) != required
+
+    def needs_background(self) -> bool:
+        return self.background_key is None
+
+    def needs_background_languages(self) -> bool:
+        if not self.background_key:
+            return False
+        background = AVAILABLE_BACKGROUNDS[self.background_key]
+        return background.language_choices > 0 and len(self.background_languages) != background.language_choices
+
+    def needs_equipment(self) -> bool:
+        if not self.class_key:
+            return False
+        character_class = AVAILABLE_CLASSES[self.class_key]
+        for choice in character_class.equipment_choices:
+            if choice.key not in self.equipment_choices:
+                return True
+            if len(self.equipment_choices[choice.key]) != choice.choose:
+                return True
+        return False
+
+    def current_step(self) -> int:
+        if self.needs_ability_scores():
+            return 1
+        if self.needs_race() or self.needs_race_languages():
+            return 2
+        if self.needs_class() or self.needs_class_skills():
+            return 3
+        if self.needs_background() or self.needs_background_languages():
+            return 4
+        if self.needs_equipment():
+            return 5
+        return 6
+
+    def is_ready(self) -> bool:
+        return self.current_step() == 6 and self.ability_scores is not None
+
+    # -- finalisation -------------------------------------------------------
+    def build_character(
+        self,
+        *,
+        guild_id: int,
+        user_id: int,
+        name: str,
+    ) -> Character:
+        if not self.is_ready():
+            raise CreationStateError("Complete all steps before finalising the character")
+        assert self.base_scores is not None
+        assert self.ability_scores is not None
+        assert self.race_key is not None
+        assert self.class_key is not None
+        assert self.background_key is not None
+        proficiencies = self._compile_proficiencies()
+        equipment = self._compile_equipment()
+        return Character(
+            guild_id=guild_id,
+            user_id=user_id,
+            race_key=self.race_key,
+            class_key=self.class_key,
+            background_key=self.background_key,
+            ability_method=self.method,
+            base_ability_scores=self.base_scores,
+            ability_scores=self.ability_scores,
+            racial_bonuses=dict(self.racial_bonuses),
+            proficiencies=tuple(proficiencies),
+            equipment=tuple(equipment),
+            name=name,
+        )
+
+    def _compile_proficiencies(self) -> list[str]:
+        entries: list[str] = []
+        if self.race_key:
+            race = AVAILABLE_RACES[self.race_key]
+            for grant in race.proficiencies:
+                label = f"Race {race.name}: {grant.category.title()} - {grant.name}"
+                if label not in entries:
+                    entries.append(label)
+        if self.class_key:
+            character_class = AVAILABLE_CLASSES[self.class_key]
+            for armor in character_class.armor_proficiencies:
+                label = f"Class {character_class.name}: Armor - {armor}"
+                if label not in entries:
+                    entries.append(label)
+            for weapon in character_class.weapon_proficiencies:
+                label = f"Class {character_class.name}: Weapon - {weapon}"
+                if label not in entries:
+                    entries.append(label)
+            for tool in character_class.tool_proficiencies:
+                label = f"Class {character_class.name}: Tool - {tool}"
+                if label not in entries:
+                    entries.append(label)
+            for skill in self.class_skill_choices:
+                label = f"Class {character_class.name}: Skill - {skill}"
+                if label not in entries:
+                    entries.append(label)
+        if self.background_key:
+            background = AVAILABLE_BACKGROUNDS[self.background_key]
+            for skill in background.skill_proficiencies:
+                label = f"Background {background.name}: Skill - {skill}"
+                if label not in entries:
+                    entries.append(label)
+            for tool in background.tool_proficiencies:
+                label = f"Background {background.name}: Tool - {tool}"
+                if label not in entries:
+                    entries.append(label)
+        return entries
+
+    def _compile_equipment(self) -> list[str]:
+        items: list[str] = []
+        if self.class_key:
+            character_class = AVAILABLE_CLASSES[self.class_key]
+            for stack in character_class.fixed_equipment:
+                items.append(stack.as_label())
+            for choice in character_class.equipment_choices:
+                selections = self.equipment_choices.get(choice.key, ())
+                for option_key in selections:
+                    option = self._find_equipment_option(choice, option_key)
+                    for stack in option.items:
+                        items.append(stack.as_label())
+        if self.background_key:
+            background = AVAILABLE_BACKGROUNDS[self.background_key]
+            for stack in background.equipment:
+                items.append(stack.as_label())
+        return items
+
+    def _find_equipment_option(self, choice: EquipmentChoice, option_key: str) -> EquipmentChoiceOption:
+        key = option_key.lower()
+        for option in choice.options:
+            if option.key == key:
+                return option
+        raise CreationStateError("Unknown equipment option")
+
+
+class AbilityAssignmentModal(discord.ui.Modal, title="Assign Ability Scores"):
+    def __init__(self, view: "CharacterCreationView") -> None:
+        super().__init__(timeout=None)
+        self.creation_view = view
+        self.inputs: list[discord.ui.TextInput] = []
+        for ability in ABILITY_NAMES:
+            component = discord.ui.TextInput(
+                label=f"{ability} score",
+                placeholder="Enter an integer value",
+                required=True,
+            )
+            self.inputs.append(component)
+            self.add_item(component)
+
+    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        assignments: Dict[str, int] = {}
+        for ability, component in zip(ABILITY_NAMES, self.inputs):
+            try:
+                assignments[ability] = int(component.value)
+            except (TypeError, ValueError):
+                await interaction.response.send_message(
+                    f"{ability} must be an integer value.", ephemeral=True
+                )
+                return
+        try:
+            self.creation_view.state.assign_scores(assignments)
+        except ValueError as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+        await self.creation_view.refresh(interaction)
+
+
+class LanguageSelectionModal(discord.ui.Modal):
+    def __init__(self, view: "CharacterCreationView", *, source: str, required: int) -> None:
+        if source == "race":
+            title = "Select Race Languages"
+        else:
+            title = "Select Background Languages"
+        super().__init__(title=title, timeout=None)
+        self.creation_view = view
+        self.source = source
+        placeholder = (
+            f"Enter {required} language name{'s' if required != 1 else ''} separated by commas."
+            if required
+            else "No languages required."
+        )
+        self.input = discord.ui.TextInput(
+            label="Languages",
+            style=discord.TextStyle.long,
+            placeholder=placeholder,
+            required=required > 0,
+            value=", ".join(view.get_languages(source)) if required else "",
+        )
+        self.add_item(self.input)
+        self.required = required
+        self.choices_hint = choices
+
+    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
+        raw_value = self.input.value or ""
+        languages = [lang.strip() for lang in raw_value.split(",") if lang.strip()]
+        try:
+            if self.source == "race":
+                self.creation_view.state.set_race_languages(languages)
+            else:
+                self.creation_view.state.set_background_languages(languages)
+        except ValueError as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+        await self.creation_view.refresh(interaction)
 
 
 class CharacterCreationView(discord.ui.View):
     def __init__(self, repository: CharacterRepository, user: discord.abc.User) -> None:
-        super().__init__(timeout=600)
+        super().__init__(timeout=900)
         self.repository = repository
         self.user = user
-        self.selected_race: Optional[str] = None
-        self.selected_class: Optional[str] = None
-        self.ability_scores: Optional[AbilityScores] = None
         self.message: Optional[discord.Message] = None
-        self.current_step: int = 1
-
-        self.race_select = RaceSelect(self)
-        self.class_select = ClassSelect(self)
-        self.ability_button = RerollAbilityScoresButton(self)
-        self.reset_button = ResetButton(self)
-        self.confirm_button = ConfirmButton(self)
-
-        self.add_item(self.race_select)
-        self.add_item(self.class_select)
-        self.add_item(self.ability_button)
-        self.add_item(self.reset_button)
-        self.add_item(self.confirm_button)
+        self.state = CreationState()
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:  # type: ignore[override]
         if interaction.user.id != self.user.id:
@@ -177,29 +462,11 @@ class CharacterCreationView(discord.ui.View):
         return True
 
     async def start(self, interaction: discord.Interaction) -> None:
-        embed = self.build_embed()
-        await interaction.response.send_message(embed=embed, view=self, ephemeral=True)
+        await interaction.response.send_message(embed=self.build_embed(), view=self, ephemeral=True)
         self.message = await interaction.original_response()
 
-    def set_ability_scores(self, scores: AbilityScores) -> None:
-        self.ability_scores = scores
-        self._update_confirm_state()
-
-    def roll_random_ability_scores(self) -> AbilityScores:
-        rolls = {ability: _roll_4d6_drop_lowest() for ability in ABILITY_NAMES}
-        scores = AbilityScores.from_dict(rolls)
-        self.set_ability_scores(scores)
-        return scores
-
-    def reset(self) -> None:
-        self.selected_race = None
-        self.selected_class = None
-        self.ability_scores = None
-        self.current_step = 1
-        self._update_confirm_state()
-
     async def refresh(self, interaction: Optional[discord.Interaction] = None) -> None:
-        self._update_confirm_state()
+        self.rebuild_items()
         embed = self.build_embed()
         if interaction is not None:
             if interaction.response.is_done():
@@ -209,108 +476,419 @@ class CharacterCreationView(discord.ui.View):
         elif self.message:
             await self.message.edit(embed=embed, view=self)
 
-    def build_embed(self) -> discord.Embed:
-        if self.current_step == 2:
-            description = (
-                "Step 2: Ability Scores\n"
-                "Your ability scores are generated by rolling 4d6 and keeping the highest three for each ability. "
-                "Use the reroll button if you'd like to try a new set before confirming."
-            )
-            embed = discord.Embed(
-                title="D&D Character Creation",
-                description=description,
-                colour=discord.Colour.blurple(),
-            )
-            embed.add_field(
-                name="Race",
-                value=self.selected_race or "Not selected",
-                inline=True,
-            )
-            embed.add_field(
-                name="Class",
-                value=self.selected_class or "Not selected",
-                inline=True,
-            )
-            if self.ability_scores:
-                embed.add_field(
-                    name="Rolled Ability Scores",
-                    value="\n".join(self._format_ability_scores()),
-                    inline=False,
-                )
-            embed.set_footer(text="Confirm to save your character once you're happy with the rolls.")
-            return embed
-
-        description = (
-            "Step 1: Choose Race & Class\n"
-            "Select your adventurer's race and class to proceed to rolling ability scores."
+    def rebuild_items(self) -> None:
+        self.clear_items()
+        step = self.state.current_step()
+        # Ability method select
+        method_select = discord.ui.Select(
+            placeholder="Choose ability score method",
+            min_values=1,
+            max_values=1,
+            options=[
+                discord.SelectOption(
+                    label="Standard Array",
+                    value="standard_array",
+                    default=self.state.method == "standard_array",
+                    description="Assign the standard 15,14,13,12,10,8 array.",
+                ),
+                discord.SelectOption(
+                    label="Point Buy",
+                    value="point_buy",
+                    default=self.state.method == "point_buy",
+                    description="Spend 27 points for scores between 8-15.",
+                ),
+            ],
         )
-        embed = discord.Embed(
-            title="D&D Character Creation",
-            description=description,
-            colour=discord.Colour.blurple(),
+
+        async def method_callback(interaction: discord.Interaction) -> None:
+            self.state.set_method(method_select.values[0])
+            await self.refresh(interaction)
+
+        method_select.callback = method_callback  # type: ignore[assignment]
+        method_select.disabled = False
+        self.add_item(method_select)
+
+        assign_button = discord.ui.Button(
+            label="Assign Ability Scores",
+            style=discord.ButtonStyle.primary,
+            disabled=step < 1,
+        )
+
+        async def assign_callback(interaction: discord.Interaction) -> None:
+            await interaction.response.send_modal(AbilityAssignmentModal(self))
+
+        assign_button.callback = assign_callback  # type: ignore[assignment]
+        assign_button.disabled = False
+        self.add_item(assign_button)
+
+        # Race selection
+        race_options = [
+            discord.SelectOption(
+                label=race.name,
+                value=race.key,
+                description=race.description[:100],
+                default=self.state.race_key == race.key,
+            )
+            for race in AVAILABLE_RACES.values()
+        ]
+        race_select = discord.ui.Select(
+            placeholder="Select a race",
+            min_values=1,
+            max_values=1,
+            options=race_options,
+        )
+
+        async def race_callback(interaction: discord.Interaction) -> None:
+            self.state.apply_race(race_select.values[0])
+            await self.refresh(interaction)
+
+        race_select.callback = race_callback  # type: ignore[assignment]
+        race_select.disabled = step < 2
+        self.add_item(race_select)
+
+        # Race language button if needed
+        if self.state.race_key:
+            race = AVAILABLE_RACES[self.state.race_key]
+            if race.languages.choices > 0:
+                race_lang_button = discord.ui.Button(
+                    label=f"Select Race Languages ({len(self.state.race_languages)}/{race.languages.choices})",
+                    style=discord.ButtonStyle.secondary,
+                )
+
+                async def race_lang_callback(interaction: discord.Interaction) -> None:
+                    await interaction.response.send_modal(
+                        LanguageSelectionModal(
+                            self, source="race", required=race.languages.choices
+                        )
+                    )
+
+                race_lang_button.callback = race_lang_callback  # type: ignore[assignment]
+                race_lang_button.disabled = step < 2
+                self.add_item(race_lang_button)
+
+        # Class selection
+        class_options = [
+            discord.SelectOption(
+                label=character_class.name,
+                value=character_class.key,
+                description=f"Hit Die d{character_class.hit_die}",
+                default=self.state.class_key == character_class.key,
+            )
+            for character_class in AVAILABLE_CLASSES.values()
+        ]
+        class_select = discord.ui.Select(
+            placeholder="Select a class",
+            min_values=1,
+            max_values=1,
+            options=class_options,
+        )
+
+        async def class_callback(interaction: discord.Interaction) -> None:
+            self.state.set_class(class_select.values[0])
+            await self.refresh(interaction)
+
+        class_select.callback = class_callback  # type: ignore[assignment]
+        class_select.disabled = step < 3
+        self.add_item(class_select)
+
+        # Class skill select
+        if self.state.class_key:
+            character_class = AVAILABLE_CLASSES[self.state.class_key]
+            skill_selection = character_class.skill_proficiency_options
+            if skill_selection.count > 0:
+                skill_select = discord.ui.Select(
+                    placeholder=f"Choose {skill_selection.count} class skill(s)",
+                    min_values=skill_selection.count,
+                    max_values=skill_selection.count,
+                    options=[
+                        discord.SelectOption(
+                            label=skill,
+                            value=skill,
+                            default=skill in self.state.class_skill_choices,
+                        )
+                        for skill in skill_selection.options
+                    ],
+                )
+
+                async def skill_callback(interaction: discord.Interaction) -> None:
+                    try:
+                        self.state.set_class_skills(skill_select.values)
+                    except ValueError as exc:
+                        await interaction.response.send_message(str(exc), ephemeral=True)
+                        return
+                    await self.refresh(interaction)
+
+                skill_select.callback = skill_callback  # type: ignore[assignment]
+                skill_select.disabled = step < 3
+                self.add_item(skill_select)
+
+        # Background selection
+        background_options = [
+            discord.SelectOption(
+                label=background.name,
+                value=background.key,
+                description=background.description[:100],
+                default=self.state.background_key == background.key,
+            )
+            for background in AVAILABLE_BACKGROUNDS.values()
+        ]
+        background_select = discord.ui.Select(
+            placeholder="Select a background",
+            min_values=1,
+            max_values=1,
+            options=background_options,
+        )
+
+        async def background_callback(interaction: discord.Interaction) -> None:
+            self.state.set_background(background_select.values[0])
+            await self.refresh(interaction)
+
+        background_select.callback = background_callback  # type: ignore[assignment]
+        background_select.disabled = step < 4
+        self.add_item(background_select)
+
+        if self.state.background_key:
+            background = AVAILABLE_BACKGROUNDS[self.state.background_key]
+            if background.language_choices > 0:
+                background_lang_button = discord.ui.Button(
+                    label=(
+                        f"Select Background Languages "
+                        f"({len(self.state.background_languages)}/{background.language_choices})"
+                    ),
+                    style=discord.ButtonStyle.secondary,
+                )
+
+                async def background_lang_callback(interaction: discord.Interaction) -> None:
+                    await interaction.response.send_modal(
+                        LanguageSelectionModal(
+                            self,
+                            source="background",
+                            required=background.language_choices,
+                        )
+                    )
+
+                background_lang_button.callback = background_lang_callback  # type: ignore[assignment]
+                background_lang_button.disabled = step < 4
+                self.add_item(background_lang_button)
+
+        # Equipment selection
+        if self.state.class_key:
+            character_class = AVAILABLE_CLASSES[self.state.class_key]
+            for choice in character_class.equipment_choices:
+                current_values = self.state.equipment_choices.get(choice.key, ())
+                equipment_select = discord.ui.Select(
+                    placeholder=f"Choose {choice.choose} option(s) for equipment",
+                    min_values=choice.choose,
+                    max_values=choice.choose,
+                    options=[
+                        discord.SelectOption(
+                            label=option.name,
+                            value=option.key,
+                            description=", ".join(stack.as_label() for stack in option.items)[:100],
+                            default=option.key in current_values,
+                        )
+                        for option in choice.options
+                    ],
+                )
+
+                async def equipment_callback(
+                    interaction: discord.Interaction,
+                    *,
+                    choice_obj: EquipmentChoice = choice,
+                    select_component: discord.ui.Select = equipment_select,
+                ) -> None:
+                    try:
+                        self.state.set_equipment_choice(choice_obj.key, select_component.values)
+                    except ValueError as exc:
+                        await interaction.response.send_message(str(exc), ephemeral=True)
+                        return
+                    await self.refresh(interaction)
+
+                equipment_select.callback = equipment_callback  # type: ignore[assignment]
+                equipment_select.disabled = step < 5
+                self.add_item(equipment_select)
+
+        # Reset and confirm buttons
+        reset_button = discord.ui.Button(label="Reset", style=discord.ButtonStyle.danger)
+
+        async def reset_callback(interaction: discord.Interaction) -> None:
+            self.state = CreationState()
+            await self.refresh(interaction)
+
+        reset_button.callback = reset_callback  # type: ignore[assignment]
+        self.add_item(reset_button)
+
+        confirm_button = discord.ui.Button(
+            label="Confirm Character", style=discord.ButtonStyle.success, disabled=not self.state.is_ready()
+        )
+
+        async def confirm_callback(interaction: discord.Interaction) -> None:
+            await self.handle_confirm(interaction)
+
+        confirm_button.callback = confirm_callback  # type: ignore[assignment]
+        self.add_item(confirm_button)
+
+    def build_embed(self) -> discord.Embed:
+        step = self.state.current_step()
+        title = "D&D Character Creation"
+        description = self._build_step_description(step)
+        embed = discord.Embed(title=title, description=description, colour=discord.Colour.blurple())
+        embed.add_field(name="Ability Method", value=self.state.method.replace("_", " ").title(), inline=True)
+        embed.add_field(
+            name="Base Ability Scores",
+            value=self._format_scores(self.state.base_scores),
+            inline=True,
+        )
+        embed.add_field(
+            name="Final Ability Scores",
+            value=self._format_scores(self.state.ability_scores),
+            inline=True,
         )
         embed.add_field(
             name="Race",
-            value=self.selected_race or "Not selected",
+            value=self._format_race_field(),
             inline=False,
         )
         embed.add_field(
             name="Class",
-            value=self.selected_class or "Not selected",
+            value=self._format_class_field(),
             inline=False,
         )
-        embed.set_footer(text="Choose a race and class to continue to Step 2.")
+        embed.add_field(
+            name="Background",
+            value=self._format_background_field(),
+            inline=False,
+        )
+        equipment = self.state._compile_equipment() if self.state.class_key else []
+        if equipment:
+            embed.add_field(
+                name="Starting Equipment",
+                value="\n".join(equipment),
+                inline=False,
+            )
+        embed.set_footer(text="Confirm once all steps are complete to save your character.")
         return embed
 
-    def build_confirmation_embed(
-        self, user: discord.abc.User, character: Character
-    ) -> discord.Embed:
-        embed = discord.Embed(
-            title=f"{character.name}",
-            description=f"{user.mention}'s freshly forged adventurer",
+    def _build_step_description(self, step: int) -> str:
+        messages = {
+            1: "Step 1: Assign ability scores using your chosen method.",
+            2: "Step 2: Select a race and resolve any language choices.",
+            3: "Step 3: Select a class and choose the required skill proficiencies.",
+            4: "Step 4: Choose a background and any additional languages it grants.",
+            5: "Step 5: Pick your starting equipment options.",
+            6: "Review your selections and confirm to save your character.",
+        }
+        return messages.get(step, "")
+
+    def _format_scores(self, scores: AbilityScores | None) -> str:
+        if not scores:
+            return "Not set"
+        return "\n".join(f"{ability}: {scores.values[ability]}" for ability in ABILITY_NAMES)
+
+    def _format_race_field(self) -> str:
+        if not self.state.race_key:
+            return "Not selected"
+        race = AVAILABLE_RACES[self.state.race_key]
+        languages = list(race.languages.fixed)
+        languages.extend(self.state.race_languages)
+        language_value = ", ".join(languages) if languages else "None"
+        bonuses = ", ".join(
+            f"{bonus.ability}+{bonus.bonus}" for bonus in race.ability_bonuses
+        )
+        return (
+            f"{race.name}\n"
+            f"Speed: {race.speed} ft.\n"
+            f"Ability Bonuses: {bonuses}\n"
+            f"Languages: {language_value}"
+        )
+
+    def _format_class_field(self) -> str:
+        if not self.state.class_key:
+            return "Not selected"
+        character_class = AVAILABLE_CLASSES[self.state.class_key]
+        skills = ", ".join(self.state.class_skill_choices) or "None"
+        return (
+            f"{character_class.name}\n"
+            f"Hit Die: d{character_class.hit_die}\n"
+            f"Class Skills: {skills}"
+        )
+
+    def _format_background_field(self) -> str:
+        if not self.state.background_key:
+            return "Not selected"
+        background = AVAILABLE_BACKGROUNDS[self.state.background_key]
+        languages = ", ".join(self.state.background_languages) or "None"
+        return (
+            f"{background.name}\n"
+            f"Skills: {', '.join(background.skill_proficiencies) or 'None'}\n"
+            f"Tools: {', '.join(background.tool_proficiencies) or 'None'}\n"
+            f"Languages: {languages}"
+        )
+
+    def get_languages(self, source: str) -> Sequence[str]:
+        if source == "race":
+            return self.state.race_languages
+        if source == "background":
+            return self.state.background_languages
+        return ()
+
+    async def handle_confirm(self, interaction: discord.Interaction) -> None:
+        if not interaction.guild:
+            await interaction.response.send_message(
+                "This command can only be used in a server.",
+                ephemeral=True,
+            )
+            return
+        if not self.state.is_ready():
+            await interaction.response.send_message(
+                "Complete all steps before confirming your character.",
+                ephemeral=True,
+            )
+            return
+        if await self.repository.exists(interaction.guild.id, interaction.user.id):
+            await interaction.response.send_message(
+                "You already have a character saved. Reset first if you want to recreate it.",
+                ephemeral=True,
+            )
+            return
+        character = self.state.build_character(
+            guild_id=interaction.guild.id,
+            user_id=interaction.user.id,
+            name=f"{interaction.user.display_name}'s Adventurer",
+        )
+        await self.repository.save(character)
+        confirmation = discord.Embed(
+            title=character.name,
+            description="Character saved successfully!",
             colour=discord.Colour.green(),
         )
-        embed.add_field(name="Race", value=character.race.name, inline=True)
-        embed.add_field(name="Class", value=character.character_class.name, inline=True)
-        embed.add_field(
+        confirmation.add_field(name="Race", value=character.race.name, inline=True)
+        confirmation.add_field(name="Class", value=character.character_class.name, inline=True)
+        confirmation.add_field(
             name="Ability Scores",
             value="\n".join(character.ability_scores.as_lines()),
             inline=False,
         )
-        embed.set_footer(text="Character saved. Use future commands to view or manage it.")
-        return embed
-
-    def _update_confirm_state(self) -> None:
-        self.confirm_button.disabled = not (
-            self.selected_race and self.selected_class and self.ability_scores
+        confirmation.add_field(
+            name="Proficiencies",
+            value="\n".join(character.proficiencies) or "None",
+            inline=False,
         )
-        self.ability_button.disabled = self.current_step != 2
-
-    def handle_step_progression(self) -> None:
-        if self.selected_race and self.selected_class:
-            if self.current_step != 2:
-                self.current_step = 2
-                if not self.ability_scores:
-                    self.roll_random_ability_scores()
-        else:
-            self.current_step = 1
-            self.ability_scores = None
-        self._update_confirm_state()
-
-    def _format_ability_scores(self) -> list[str]:
-        if not self.ability_scores:
-            return []
-        return [
-            f"**{ability}** — {self.ability_scores.values[ability]}"
-            for ability in ABILITY_NAMES
-        ]
+        confirmation.add_field(
+            name="Equipment",
+            value="\n".join(character.equipment) or "None",
+            inline=False,
+        )
+        confirmation.set_footer(text="Use /character view to inspect your saved hero.")
+        if self.message:
+            await self.message.edit(embed=confirmation, view=None)
+        await interaction.response.send_message("Character saved successfully!", ephemeral=True)
+        self.stop()
 
     async def on_timeout(self) -> None:
         if self.message:
             timeout_embed = self.build_embed()
-            timeout_embed.set_footer(
-                text="Session expired. Run /character create again to restart."
-            )
+            timeout_embed.set_footer(text="Session expired. Run /character create again to restart.")
             await self.message.edit(embed=timeout_embed, view=None)
 
 
@@ -328,7 +906,6 @@ class CharacterCreation(commands.GroupCog, name="character", description="Create
                 ephemeral=True,
             )
             return
-
         existing = await self.repository.exists(interaction.guild.id, interaction.user.id)
         if existing:
             await interaction.response.send_message(
@@ -336,9 +913,10 @@ class CharacterCreation(commands.GroupCog, name="character", description="Create
                 ephemeral=True,
             )
             return
-
         view = CharacterCreationView(self.repository, interaction.user)
+        view.rebuild_items()
         await view.start(interaction)
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(CharacterCreation(bot))

--- a/dnd/__init__.py
+++ b/dnd/__init__.py
@@ -2,9 +2,12 @@
 
 from .characters import (
     ABILITY_NAMES,
+    AVAILABLE_BACKGROUNDS,
     AVAILABLE_CLASSES,
     AVAILABLE_RACES,
+    EQUIPMENT,
     AbilityScores,
+    Background,
     Character,
     CharacterClass,
     Race,
@@ -43,9 +46,12 @@ from .tavern import TavernConfig, TavernConfigStore
 
 __all__ = [
     "ABILITY_NAMES",
+    "AVAILABLE_BACKGROUNDS",
     "AVAILABLE_CLASSES",
     "AVAILABLE_RACES",
+    "EQUIPMENT",
     "AbilityScores",
+    "Background",
     "Character",
     "CharacterClass",
     "Race",

--- a/dnd/characters.py
+++ b/dnd/characters.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, Mapping
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, MutableMapping, Sequence
+
+import yaml
 
 ABILITY_NAMES: tuple[str, ...] = ("STR", "DEX", "CON", "INT", "WIS", "CHA")
 STANDARD_ARRAY: tuple[int, ...] = (15, 14, 13, 12, 10, 8)
@@ -19,47 +23,115 @@ POINT_BUY_COSTS: Mapping[int, int] = {
 }
 POINT_BUY_BUDGET: int = 27
 
+_SRD_PATH = Path(__file__).with_name("content") / "srd"
+
+
+class SRDLoadError(RuntimeError):
+    """Raised when SRD data fails validation."""
+
 
 @dataclass(frozen=True)
-class Race:
-    """Represents a D&D playable race."""
+class AbilityBonus:
+    ability: str
+    bonus: int
 
+
+@dataclass(frozen=True)
+class Feature:
+    level: int
     name: str
     description: str
 
 
 @dataclass(frozen=True)
-class CharacterClass:
-    """Represents a D&D character class."""
+class ProficiencyGrant:
+    category: str
+    name: str
 
+
+@dataclass(frozen=True)
+class LanguageProfile:
+    fixed: tuple[str, ...] = field(default_factory=tuple)
+    choices: int = 0
+
+
+@dataclass(frozen=True)
+class EquipmentItem:
+    key: str
+    name: str
+    category: str | None = None
+
+
+@dataclass(frozen=True)
+class EquipmentStack:
+    item: EquipmentItem
+    quantity: int = 1
+
+    def as_label(self) -> str:
+        return f"{self.quantity} x {self.item.name}" if self.quantity > 1 else self.item.name
+
+
+@dataclass(frozen=True)
+class EquipmentChoiceOption:
+    key: str
+    name: str
+    items: tuple[EquipmentStack, ...]
+
+    def as_summary(self) -> str:
+        parts = [stack.as_label() for stack in self.items]
+        return f"{self.name}: " + ", ".join(parts)
+
+
+@dataclass(frozen=True)
+class EquipmentChoice:
+    key: str
+    choose: int
+    options: tuple[EquipmentChoiceOption, ...]
+
+
+@dataclass(frozen=True)
+class SkillSelection:
+    count: int
+    options: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Race:
+    key: str
+    name: str
+    description: str
+    ability_bonuses: tuple[AbilityBonus, ...]
+    speed: int
+    proficiencies: tuple[ProficiencyGrant, ...]
+    languages: LanguageProfile
+    traits: tuple[Feature, ...]
+
+
+@dataclass(frozen=True)
+class CharacterClass:
+    key: str
     name: str
     hit_die: int
-    primary_ability: str
+    primary_abilities: tuple[str, ...]
+    saving_throws: tuple[str, ...]
+    armor_proficiencies: tuple[str, ...]
+    weapon_proficiencies: tuple[str, ...]
+    tool_proficiencies: tuple[str, ...]
+    skill_proficiency_options: SkillSelection
+    equipment_choices: tuple[EquipmentChoice, ...]
+    fixed_equipment: tuple[EquipmentStack, ...]
+    features: tuple[Feature, ...]
 
 
-AVAILABLE_RACES: Dict[str, Race] = {
-    race.name: race
-    for race in (
-        Race("Human", "Adaptable and ambitious, humans thrive in any environment."),
-        Race("Elf", "Graceful spellcasters with keen senses and a love for nature."),
-        Race("Dwarf", "Stout warriors renowned for their resilience and craftsmanship."),
-        Race("Halfling", "Nimble travelers with uncanny luck and warm hearts."),
-        Race("Dragonborn", "Descendants of dragons who channel elemental power."),
-        Race("Tiefling", "Planetouched folk wielding innate infernal magic."),
-    )
-}
-
-AVAILABLE_CLASSES: Dict[str, CharacterClass] = {
-    c.name: c
-    for c in (
-        CharacterClass("Fighter", hit_die=10, primary_ability="STR"),
-        CharacterClass("Wizard", hit_die=6, primary_ability="INT"),
-        CharacterClass("Rogue", hit_die=8, primary_ability="DEX"),
-        CharacterClass("Cleric", hit_die=8, primary_ability="WIS"),
-        CharacterClass("Paladin", hit_die=10, primary_ability="CHA"),
-        CharacterClass("Ranger", hit_die=10, primary_ability="DEX"),
-    )
-}
+@dataclass(frozen=True)
+class Background:
+    key: str
+    name: str
+    description: str
+    skill_proficiencies: tuple[str, ...]
+    tool_proficiencies: tuple[str, ...]
+    language_choices: int
+    equipment: tuple[EquipmentStack, ...]
 
 
 @dataclass
@@ -72,6 +144,10 @@ class AbilityScores:
         missing = set(ABILITY_NAMES) - set(self.values)
         if missing:
             raise ValueError(f"Missing ability scores for: {', '.join(sorted(missing))}")
+        for ability, value in self.values.items():
+            if ability not in ABILITY_NAMES:
+                raise ValueError(f"Unknown ability '{ability}'")
+            self.values[ability] = int(value)
 
     @classmethod
     def from_assignments(
@@ -94,6 +170,15 @@ class AbilityScores:
 
         return cls(dict(assignments))
 
+    def with_bonuses(self, bonuses: Mapping[str, int]) -> "AbilityScores":
+        updated = {ability: self.values[ability] for ability in ABILITY_NAMES}
+        for ability, bonus in bonuses.items():
+            upper = ability.upper()
+            if upper not in ABILITY_NAMES:
+                raise ValueError(f"Unknown ability '{ability}' in bonuses")
+            updated[upper] = updated.get(upper, 0) + int(bonus)
+        return AbilityScores(updated)
+
     def as_lines(self) -> Iterable[str]:
         return (f"{ability}: {self.values[ability]}" for ability in ABILITY_NAMES)
 
@@ -104,6 +189,14 @@ class AbilityScores:
     def from_dict(cls, data: Mapping[str, int]) -> "AbilityScores":
         return cls(dict(data))
 
+    def point_buy_total(self) -> int:
+        total = 0
+        for value in self.values.values():
+            if value not in POINT_BUY_COSTS:
+                raise ValueError("Point buy costs undefined for score %s" % value)
+            total += POINT_BUY_COSTS[value]
+        return total
+
 
 @dataclass
 class Character:
@@ -111,36 +204,76 @@ class Character:
 
     guild_id: int
     user_id: int
-    race: Race
-    character_class: CharacterClass
+    race_key: str
+    class_key: str
+    background_key: str | None
+    ability_method: str
+    base_ability_scores: AbilityScores
     ability_scores: AbilityScores
-    name: str
+    racial_bonuses: Dict[str, int]
+    proficiencies: tuple[str, ...]
+    equipment: tuple[str, ...]
+    name: str = "Unnamed Adventurer"
+
+    @property
+    def race(self) -> Race:
+        return AVAILABLE_RACES[self.race_key]
+
+    @property
+    def character_class(self) -> CharacterClass:
+        return AVAILABLE_CLASSES[self.class_key]
+
+    @property
+    def background(self) -> Background | None:
+        if self.background_key is None:
+            return None
+        return AVAILABLE_BACKGROUNDS[self.background_key]
 
     def to_dict(self) -> Dict[str, object]:
         return {
             "guild_id": self.guild_id,
             "user_id": self.user_id,
-            "race": self.race.name,
-            "class": self.character_class.name,
+            "race": self.race_key,
+            "class": self.class_key,
+            "background": self.background_key,
+            "ability_method": self.ability_method,
+            "base_ability_scores": self.base_ability_scores.to_dict(),
             "ability_scores": self.ability_scores.to_dict(),
+            "racial_bonuses": dict(self.racial_bonuses),
+            "proficiencies": list(self.proficiencies),
+            "equipment": list(self.equipment),
             "name": self.name,
         }
 
     @classmethod
     def from_dict(cls, data: Mapping[str, object]) -> "Character":
-        race_name = str(data["race"])
-        class_name = str(data["class"])
-        race = AVAILABLE_RACES[race_name]
-        character_class = AVAILABLE_CLASSES[class_name]
+        race_key = str(data["race"]).lower()
+        class_key = str(data["class"]).lower()
+        background_value = data.get("background")
+        background_key = str(background_value).lower() if background_value else None
+        base_source = data.get("base_ability_scores") or data.get("ability_scores")
+        if base_source is None:
+            raise KeyError("base_ability_scores")
+        base_scores = AbilityScores.from_dict({k: int(v) for k, v in dict(base_source).items()})
+        ability_source = data.get("ability_scores") or base_source
         ability_scores = AbilityScores.from_dict(
-            {k: int(v) for k, v in dict(data["ability_scores"]).items()}
+            {k: int(v) for k, v in dict(ability_source).items()}
         )
+        racial_bonuses = {k.upper(): int(v) for k, v in dict(data.get("racial_bonuses", {})).items()}
+        proficiencies = tuple(str(value) for value in data.get("proficiencies", []))
+        equipment = tuple(str(value) for value in data.get("equipment", []))
         return cls(
             guild_id=int(data["guild_id"]),
             user_id=int(data["user_id"]),
-            race=race,
-            character_class=character_class,
+            race_key=race_key,
+            class_key=class_key,
+            background_key=background_key,
+            ability_method=str(data.get("ability_method", "standard_array")),
+            base_ability_scores=base_scores,
             ability_scores=ability_scores,
+            racial_bonuses=racial_bonuses,
+            proficiencies=proficiencies,
+            equipment=equipment,
             name=str(data.get("name", "Unnamed Adventurer")),
         )
 
@@ -173,3 +306,265 @@ def _validate_point_buy(values: Iterable[int]) -> None:
             "Point buy total exceeds budget of "
             f"{POINT_BUY_BUDGET} points (used {total_cost})."
         )
+
+
+def _load_yaml(path: Path) -> object:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - defensive
+        raise SRDLoadError(f"Unable to read SRD data from {path}") from exc
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive
+        raise SRDLoadError(f"Failed to parse SRD data from {path}") from exc
+    return data or []
+
+
+def _require_mapping(name: str, value: object) -> MutableMapping[str, object]:
+    if isinstance(value, MutableMapping):
+        return value
+    if isinstance(value, Mapping):
+        return dict(value)
+    raise SRDLoadError(f"Expected mapping for {name}")
+
+
+def _require_sequence(name: str, value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return value
+    raise SRDLoadError(f"Expected sequence for {name}")
+
+
+def _load_equipment() -> Dict[str, EquipmentItem]:
+    path = _SRD_PATH / "equipment.yaml"
+    raw = _load_yaml(path)
+    if not isinstance(raw, Mapping):
+        raise SRDLoadError("equipment.yaml must contain a mapping of items")
+    items_section = raw.get("items", {})
+    items_mapping = _require_mapping("equipment.items", items_section)
+    equipment: Dict[str, EquipmentItem] = {}
+    for key, value in items_mapping.items():
+        item_map = _require_mapping(f"equipment item {key}", value)
+        name = str(item_map.get("name") or key)
+        category_raw = item_map.get("category")
+        category = str(category_raw) if category_raw is not None else None
+        equipment_key = str(key).lower()
+        equipment[equipment_key] = EquipmentItem(key=equipment_key, name=name, category=category)
+    return equipment
+
+
+def _load_races() -> Dict[str, Race]:
+    path = _SRD_PATH / "races.yaml"
+    raw = _load_yaml(path)
+    races: Dict[str, Race] = {}
+    for entry in _require_sequence("races", raw):
+        mapping = _require_mapping("race entry", entry)
+        key = str(mapping.get("key") or mapping.get("id") or mapping.get("name")).lower()
+        if not key:
+            raise SRDLoadError("Race entry missing key")
+        name = str(mapping.get("name") or key.title())
+        description = str(mapping.get("description", ""))
+        ability_raw = mapping.get("ability_bonuses", {})
+        ability_map = _require_mapping(f"{key}.ability_bonuses", ability_raw)
+        ability_bonuses = tuple(
+            AbilityBonus(ability=str(ability).upper(), bonus=int(value))
+            for ability, value in ability_map.items()
+        )
+        speed = int(mapping.get("speed", 30))
+        proficiencies_raw = mapping.get("proficiencies", [])
+        proficiencies: list[ProficiencyGrant] = []
+        for prof in _require_sequence(f"{key}.proficiencies", proficiencies_raw):
+            prof_map = _require_mapping(f"{key}.proficiency", prof)
+            category = str(prof_map.get("category") or "general").lower()
+            name_value = prof_map.get("name")
+            if not name_value:
+                raise SRDLoadError(f"Proficiency entry for race {key} missing name")
+            proficiencies.append(ProficiencyGrant(category=category, name=str(name_value)))
+        languages_raw = mapping.get("languages", {})
+        languages_map = _require_mapping(f"{key}.languages", languages_raw)
+        fixed_raw = languages_map.get("fixed", [])
+        fixed_languages = tuple(str(lang) for lang in _require_sequence(f"{key}.languages.fixed", fixed_raw))
+        choices = int(languages_map.get("choices", 0))
+        traits_raw = mapping.get("traits", [])
+        traits: list[Feature] = []
+        for trait in _require_sequence(f"{key}.traits", traits_raw):
+            trait_map = _require_mapping(f"{key}.trait", trait)
+            level = int(trait_map.get("level", 1))
+            trait_name = str(trait_map.get("name", "Trait"))
+            trait_description = str(trait_map.get("description", ""))
+            traits.append(Feature(level=level, name=trait_name, description=trait_description))
+        races[key] = Race(
+            key=key,
+            name=name,
+            description=description,
+            ability_bonuses=tuple(ability_bonuses),
+            speed=speed,
+            proficiencies=tuple(proficiencies),
+            languages=LanguageProfile(fixed=fixed_languages, choices=choices),
+            traits=tuple(traits),
+        )
+    return races
+
+
+def _parse_equipment_list(
+    owner_key: str,
+    raw: object,
+    equipment_lookup: Mapping[str, EquipmentItem],
+) -> tuple[EquipmentStack, ...]:
+    if raw is None:
+        return ()
+    sequence = _require_sequence(f"{owner_key}.equipment", raw)
+    order: list[tuple[str, int]] = []
+    for element in sequence:
+        if isinstance(element, str):
+            key = element
+            quantity = 1
+        elif isinstance(element, Mapping):
+            elem_map = _require_mapping(f"{owner_key}.equipment entry", element)
+            key_value = elem_map.get("item") or elem_map.get("key") or elem_map.get("id")
+            if not key_value:
+                raise SRDLoadError(f"Equipment entry for {owner_key} missing item key")
+            key = str(key_value)
+            quantity = int(elem_map.get("quantity", 1))
+        else:
+            raise SRDLoadError(f"Invalid equipment entry in {owner_key}")
+        equipment_key = str(key).lower()
+        if quantity < 1:
+            raise SRDLoadError(f"Invalid quantity for {owner_key} equipment {equipment_key}")
+        order.append((equipment_key, quantity))
+    aggregated: "OrderedDict[str, int]" = OrderedDict()
+    for key, quantity in order:
+        aggregated[key] = aggregated.get(key, 0) + quantity
+    stacks: list[EquipmentStack] = []
+    for key, quantity in aggregated.items():
+        try:
+            item = equipment_lookup[key]
+        except KeyError as exc:
+            raise SRDLoadError(f"Unknown equipment '{key}' referenced in {owner_key}") from exc
+        stacks.append(EquipmentStack(item=item, quantity=quantity))
+    return tuple(stacks)
+
+
+def _load_classes(equipment_lookup: Mapping[str, EquipmentItem]) -> Dict[str, CharacterClass]:
+    path = _SRD_PATH / "classes.yaml"
+    raw = _load_yaml(path)
+    classes: Dict[str, CharacterClass] = {}
+    for entry in _require_sequence("classes", raw):
+        mapping = _require_mapping("class entry", entry)
+        key = str(mapping.get("key") or mapping.get("id") or mapping.get("name")).lower()
+        if not key:
+            raise SRDLoadError("Class entry missing key")
+        name = str(mapping.get("name") or key.title())
+        hit_die = int(mapping.get("hit_die", 6))
+        primary = tuple(str(v).upper() for v in mapping.get("primary_abilities", []))
+        saving = tuple(str(v).upper() for v in mapping.get("saving_throws", []))
+        armor = tuple(str(v) for v in mapping.get("armor_proficiencies", []))
+        weapons = tuple(str(v) for v in mapping.get("weapon_proficiencies", []))
+        tools = tuple(str(v) for v in mapping.get("tool_proficiencies", []))
+        skill_raw = mapping.get("skill_proficiency_options", {})
+        skill_map = _require_mapping(f"{key}.skill_proficiency_options", skill_raw)
+        count = int(skill_map.get("count", 0))
+        options = tuple(str(v) for v in _require_sequence(f"{key}.skill options", skill_map.get("options", [])))
+        skill_selection = SkillSelection(count=count, options=options)
+        equipment_data = _require_mapping(f"{key}.equipment", mapping.get("equipment", {}))
+        fixed_equipment = _parse_equipment_list(f"{key}.equipment.fixed", equipment_data.get("fixed", []), equipment_lookup)
+        choices_raw = equipment_data.get("choices", [])
+        choices: list[EquipmentChoice] = []
+        for choice_entry in _require_sequence(f"{key}.equipment.choices", choices_raw):
+            choice_map = _require_mapping(f"{key}.equipment.choice", choice_entry)
+            choice_key = str(choice_map.get("key") or f"{key}_choice_{len(choices)}").lower()
+            choose = int(choice_map.get("choose", 1))
+            options_raw = choice_map.get("options", [])
+            option_values: list[EquipmentChoiceOption] = []
+            for option in _require_sequence(f"{choice_key}.options", options_raw):
+                option_map = _require_mapping(f"{choice_key}.option", option)
+                option_key = str(option_map.get("key") or f"{choice_key}_option_{len(option_values)}").lower()
+                option_name = str(option_map.get("name", option_key.title()))
+                option_items = _parse_equipment_list(
+                    f"{choice_key}.option.{option_key}", option_map.get("items", []), equipment_lookup
+                )
+                option_values.append(
+                    EquipmentChoiceOption(key=option_key, name=option_name, items=option_items)
+                )
+            choices.append(EquipmentChoice(key=choice_key, choose=max(1, choose), options=tuple(option_values)))
+        features_raw = mapping.get("features", [])
+        features: list[Feature] = []
+        for feature in _require_sequence(f"{key}.features", features_raw):
+            feature_map = _require_mapping(f"{key}.feature", feature)
+            level = int(feature_map.get("level", 1))
+            feature_name = str(feature_map.get("name", "Feature"))
+            feature_description = str(feature_map.get("description", ""))
+            features.append(Feature(level=level, name=feature_name, description=feature_description))
+        classes[key] = CharacterClass(
+            key=key,
+            name=name,
+            hit_die=hit_die,
+            primary_abilities=primary,
+            saving_throws=saving,
+            armor_proficiencies=armor,
+            weapon_proficiencies=weapons,
+            tool_proficiencies=tools,
+            skill_proficiency_options=skill_selection,
+            equipment_choices=tuple(choices),
+            fixed_equipment=fixed_equipment,
+            features=tuple(features),
+        )
+    return classes
+
+
+def _load_backgrounds(equipment_lookup: Mapping[str, EquipmentItem]) -> Dict[str, Background]:
+    path = _SRD_PATH / "backgrounds.yaml"
+    raw = _load_yaml(path)
+    backgrounds: Dict[str, Background] = {}
+    for entry in _require_sequence("backgrounds", raw):
+        mapping = _require_mapping("background entry", entry)
+        key = str(mapping.get("key") or mapping.get("id") or mapping.get("name")).lower()
+        if not key:
+            raise SRDLoadError("Background entry missing key")
+        name = str(mapping.get("name") or key.title())
+        description = str(mapping.get("description", ""))
+        skill_profs = tuple(str(v) for v in mapping.get("skill_proficiencies", []))
+        tool_profs = tuple(str(v) for v in mapping.get("tool_proficiencies", []))
+        language_choices = int(mapping.get("language_choices", 0))
+        equipment = _parse_equipment_list(f"{key}.equipment", mapping.get("equipment", []), equipment_lookup)
+        backgrounds[key] = Background(
+            key=key,
+            name=name,
+            description=description,
+            skill_proficiencies=skill_profs,
+            tool_proficiencies=tool_profs,
+            language_choices=language_choices,
+            equipment=equipment,
+        )
+    return backgrounds
+
+
+EQUIPMENT: Dict[str, EquipmentItem] = _load_equipment()
+AVAILABLE_RACES: Dict[str, Race] = _load_races()
+AVAILABLE_CLASSES: Dict[str, CharacterClass] = _load_classes(EQUIPMENT)
+AVAILABLE_BACKGROUNDS: Dict[str, Background] = _load_backgrounds(EQUIPMENT)
+
+
+__all__ = [
+    "ABILITY_NAMES",
+    "STANDARD_ARRAY",
+    "POINT_BUY_COSTS",
+    "POINT_BUY_BUDGET",
+    "AbilityBonus",
+    "Feature",
+    "ProficiencyGrant",
+    "LanguageProfile",
+    "EquipmentItem",
+    "EquipmentStack",
+    "EquipmentChoice",
+    "EquipmentChoiceOption",
+    "SkillSelection",
+    "Race",
+    "CharacterClass",
+    "Background",
+    "AbilityScores",
+    "Character",
+    "AVAILABLE_RACES",
+    "AVAILABLE_CLASSES",
+    "AVAILABLE_BACKGROUNDS",
+    "EQUIPMENT",
+]

--- a/dnd/content/srd/backgrounds.yaml
+++ b/dnd/content/srd/backgrounds.yaml
@@ -1,0 +1,25 @@
+- key: acolyte
+  name: Acolyte
+  skill_proficiencies:
+    - Insight
+    - Religion
+  tool_proficiencies: []
+  language_choices: 2
+  equipment:
+    - holy_symbol
+    - explorers_pack
+  description: You spent your life in service to a temple.
+- key: soldier
+  name: Soldier
+  skill_proficiencies:
+    - Athletics
+    - Intimidation
+  tool_proficiencies:
+    - Gaming set (choice)
+    - Vehicles (land)
+  language_choices: 0
+  equipment:
+    - insignia_of_rank
+    - trophy_of_war
+    - dungeoneers_pack
+  description: You served in a militia or army.

--- a/dnd/content/srd/classes.yaml
+++ b/dnd/content/srd/classes.yaml
@@ -1,0 +1,170 @@
+- key: fighter
+  name: Fighter
+  hit_die: 10
+  primary_abilities:
+    - STR
+    - CON
+  saving_throws:
+    - STR
+    - CON
+  armor_proficiencies:
+    - All armor
+    - Shields
+  weapon_proficiencies:
+    - Simple weapons
+    - Martial weapons
+  tool_proficiencies: []
+  skill_proficiency_options:
+    count: 2
+    options:
+      - Acrobatics
+      - Animal Handling
+      - Athletics
+      - History
+      - Insight
+      - Intimidation
+      - Perception
+      - Survival
+  equipment:
+    fixed:
+      - explorers_pack
+    choices:
+      - key: fighter_weapon
+        choose: 1
+        options:
+          - key: fighter_defense
+            name: Chain Mail, shield, and longsword
+            items:
+              - chain_mail
+              - shield
+              - longsword
+          - key: fighter_archer
+            name: Leather armor, longbow, and 20 arrows
+            items:
+              - leather_armor
+              - longbow
+              - arrows_20
+  features:
+    - level: 1
+      name: Fighting Style
+      description: You adopt a particular style of fighting as your specialty.
+    - level: 1
+      name: Second Wind
+      description: You can use a bonus action to regain hit points.
+- key: wizard
+  name: Wizard
+  hit_die: 6
+  primary_abilities:
+    - INT
+  saving_throws:
+    - INT
+    - WIS
+  armor_proficiencies: []
+  weapon_proficiencies:
+    - Daggers
+    - Darts
+    - Slings
+    - Quarterstaffs
+    - Light crossbows
+  tool_proficiencies: []
+  skill_proficiency_options:
+    count: 2
+    options:
+      - Arcana
+      - History
+      - Insight
+      - Investigation
+      - Medicine
+      - Religion
+  equipment:
+    fixed:
+      - spellbook
+    choices:
+      - key: wizard_focus
+        choose: 1
+        options:
+          - key: wizard_component
+            name: Component pouch and scholar's pack
+            items:
+              - component_pouch
+              - scholars_pack
+          - key: wizard_focus
+            name: Quarterstaff and scholar's pack
+            items:
+              - quarterstaff
+              - scholars_pack
+  features:
+    - level: 1
+      name: Spellcasting
+      description: You have learned to untangle and reshape the fabric of reality.
+    - level: 1
+      name: Arcane Recovery
+      description: You regain some spell slots on a short rest.
+- key: rogue
+  name: Rogue
+  hit_die: 8
+  primary_abilities:
+    - DEX
+    - INT
+  saving_throws:
+    - DEX
+    - INT
+  armor_proficiencies:
+    - Light armor
+  weapon_proficiencies:
+    - Simple weapons
+    - Hand crossbows
+    - Longswords
+    - Rapiers
+    - Shortswords
+  tool_proficiencies:
+    - Thieves' tools
+  skill_proficiency_options:
+    count: 4
+    options:
+      - Acrobatics
+      - Athletics
+      - Deception
+      - Insight
+      - Intimidation
+      - Investigation
+      - Perception
+      - Performance
+      - Persuasion
+      - Sleight of Hand
+      - Stealth
+  equipment:
+    fixed:
+      - burglars_pack
+    choices:
+      - key: rogue_weapon
+        choose: 1
+        options:
+          - key: rogue_rapier
+            name: Rapier
+            items:
+              - rapier
+          - key: rogue_shortsword
+            name: Shortsword pair
+            items:
+              - shortsword_pair
+      - key: rogue_ranged
+        choose: 1
+        options:
+          - key: rogue_shortbow
+            name: Shortbow and quiver of 20 arrows
+            items:
+              - shortbow
+              - arrows_20_shortbow
+          - key: rogue_daggers
+            name: Two daggers
+            items:
+              - dagger
+              - dagger
+  features:
+    - level: 1
+      name: Sneak Attack
+      description: Deal extra damage to creatures you hit with finesse or ranged weapons.
+    - level: 1
+      name: Thieves' Cant
+      description: You have learned thieves' cant, a secret mix of dialect, jargon, and code.

--- a/dnd/content/srd/equipment.yaml
+++ b/dnd/content/srd/equipment.yaml
@@ -1,0 +1,79 @@
+items:
+  chain_mail:
+    name: Chain Mail
+    category: Armor
+  leather_armor:
+    name: Leather Armor
+    category: Armor
+  longsword:
+    name: Longsword
+    category: Weapon
+  shield:
+    name: Shield
+    category: Armor
+  longbow:
+    name: Longbow
+    category: Weapon
+  arrows_20:
+    name: Arrows (20)
+    category: Ammunition
+  shortsword_pair:
+    name: Two Shortswords
+    category: Weapon
+  component_pouch:
+    name: Component Pouch
+    category: Gear
+  spellbook:
+    name: Spellbook
+    category: Gear
+  dagger:
+    name: Dagger
+    category: Weapon
+  explorers_pack:
+    name: Explorer's Pack
+    category: Pack
+  dungeoneers_pack:
+    name: Dungeoneer's Pack
+    category: Pack
+  burglars_pack:
+    name: Burglar's Pack
+    category: Pack
+  holy_symbol:
+    name: Holy Symbol
+    category: Gear
+  mace:
+    name: Mace
+    category: Weapon
+  scale_mail:
+    name: Scale Mail
+    category: Armor
+  light_crossbow:
+    name: Light Crossbow
+    category: Weapon
+  bolts_20:
+    name: Crossbow Bolts (20)
+    category: Ammunition
+  quarterstaff:
+    name: Quarterstaff
+    category: Weapon
+  scholars_pack:
+    name: Scholar's Pack
+    category: Pack
+  thieves_tools:
+    name: Thieves' Tools
+    category: Tool
+  rapier:
+    name: Rapier
+    category: Weapon
+  shortbow:
+    name: Shortbow
+    category: Weapon
+  arrows_20_shortbow:
+    name: Shortbow Arrows (20)
+    category: Ammunition
+  insignia_of_rank:
+    name: Insignia of Rank
+    category: Gear
+  trophy_of_war:
+    name: Trophy of War
+    category: Gear

--- a/dnd/content/srd/races.yaml
+++ b/dnd/content/srd/races.yaml
@@ -1,0 +1,72 @@
+- key: human
+  name: Human
+  description: Adaptable folk found throughout the realms.
+  ability_bonuses:
+    STR: 1
+    DEX: 1
+    CON: 1
+    INT: 1
+    WIS: 1
+    CHA: 1
+  speed: 30
+  proficiencies: []
+  languages:
+    fixed:
+      - Common
+    choices: 1
+  traits:
+    - level: 1
+      name: Extra Language
+      description: You gain one additional language of your choice.
+- key: elf
+  name: High Elf
+  description: Graceful spellcasters with keen senses.
+  ability_bonuses:
+    DEX: 2
+    INT: 1
+  speed: 30
+  proficiencies:
+    - category: weapon
+      name: Longsword
+    - category: weapon
+      name: Shortsword
+    - category: weapon
+      name: Shortbow
+    - category: weapon
+      name: Longbow
+    - category: skill
+      name: Perception
+  languages:
+    fixed:
+      - Common
+      - Elvish
+    choices: 0
+  traits:
+    - level: 1
+      name: Trance
+      description: Elves meditate instead of sleeping.
+- key: dwarf
+  name: Hill Dwarf
+  description: Stout and hardy folk of the mountains.
+  ability_bonuses:
+    CON: 2
+    WIS: 1
+  speed: 25
+  proficiencies:
+    - category: weapon
+      name: Battleaxe
+    - category: weapon
+      name: Handaxe
+    - category: weapon
+      name: Light Hammer
+    - category: weapon
+      name: Warhammer
+  languages:
+    fixed:
+      - Common
+      - Dwarvish
+    choices: 0
+  traits:
+    - level: 1
+      name: Dwarven Toughness
+      description: Your hit point maximum increases by 1, and increases by 1 every time you gain a level.

--- a/docs/character_creation.md
+++ b/docs/character_creation.md
@@ -1,0 +1,23 @@
+# Character Creation Flow
+
+The interactive `/character create` command now walks players through a six-step
+process that mirrors the official SRD onboarding rules.
+
+1. **Ability Assignment** – Choose the standard array or point-buy method and
+   provide values for all six ability scores. Point-buy totals are validated
+   against the 27 point budget.
+2. **Race Selection** – Pick a race from the SRD catalog. Racial ability score
+   increases are applied immediately, and any required language choices are
+   enforced.
+3. **Class Configuration** – Choose a class, then select the exact number of
+   skill proficiencies required by that class.
+4. **Background & Languages** – Choose a background and satisfy any additional
+   language proficiencies granted by it.
+5. **Starting Equipment** – Resolve every class equipment choice (each option is
+   drawn from the SRD starting packages) before continuing.
+6. **Confirmation** – Review the full summary (ability scores, proficiencies,
+   equipment) and confirm to persist the character.
+
+If any SRD rule is violated (for example selecting too many skills or
+overspending on point-buy) the bot returns a descriptive, actionable error. Use
+the **Reset** button at any time to restart the workflow.

--- a/tests/test_character_models.py
+++ b/tests/test_character_models.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from cogs.character_creation import CreationState, CreationStateError
+from dnd.characters import ABILITY_NAMES, AbilityScores, Character
+
+
+def test_point_buy_validation() -> None:
+    assignments = {ability: 8 for ability in ABILITY_NAMES}
+    scores = AbilityScores.from_assignments(assignments, method="point_buy")
+    assert scores.point_buy_total() == 0
+    with pytest.raises(ValueError):
+        AbilityScores.from_assignments({"STR": 18, **{ability: 8 for ability in ABILITY_NAMES if ability != "STR"}}, method="point_buy")
+
+
+def test_character_serialization_round_trip() -> None:
+    state = CreationState()
+    base_assignments = {
+        "STR": 15,
+        "DEX": 14,
+        "CON": 13,
+        "INT": 12,
+        "WIS": 10,
+        "CHA": 8,
+    }
+    state.assign_scores(base_assignments, method="standard_array")
+    state.apply_race("human")
+    state.set_race_languages(["Dwarvish"])
+    state.set_class("fighter")
+    state.set_class_skills(["Athletics", "Perception"])
+    state.set_equipment_choice("fighter_weapon", ["fighter_defense"])
+    state.set_background("acolyte")
+    state.set_background_languages(["Giant", "Gnomish"])
+    assert state.current_step() == 6
+    assert state.is_ready()
+
+    character = state.build_character(guild_id=123, user_id=456, name="Test Hero")
+    payload = character.to_dict()
+    restored = Character.from_dict(payload)
+
+    assert restored.ability_scores.values["STR"] == 16  # human bonus applied
+    assert restored.base_ability_scores.values["STR"] == 15
+    assert restored.racial_bonuses["STR"] == 1
+    assert any("Class Fighter: Skill - Athletics" in entry for entry in restored.proficiencies)
+    assert any("Background Acolyte: Skill - Insight" in entry for entry in restored.proficiencies)
+    assert restored.equipment
+
+
+def test_creation_state_validations() -> None:
+    state = CreationState()
+    with pytest.raises(CreationStateError):
+        state.apply_race("human")
+    state.assign_scores({ability: 8 for ability in ABILITY_NAMES}, method="point_buy")
+    state.apply_race("elf")
+    state.set_class("wizard")
+    with pytest.raises(CreationStateError):
+        state.set_class_skills(["Athletics"])  # not in wizard options
+    state.set_class_skills(["Arcana", "History"])
+    state.set_equipment_choice("wizard_focus", ["wizard_component"])
+    state.set_background("soldier")
+    assert state.needs_background_languages() is False
+    assert state.needs_equipment() is False
+    assert state.current_step() == 6


### PR DESCRIPTION
## Summary
- load SRD race, class, background, and equipment data from structured YAML and expose richer domain models
- expand character persistence to include ability assignment details, proficiencies, and starting gear
- rebuild the Discord character creation flow into a validated multi-step wizard and document/test the experience

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcda77c8108329af8cd75f1746c4b6