### PR TITLE
Add combat advantage utilities and damage resolution helpers

### DIFF
--- a/dnd/combat.py
+++ b/dnd/combat.py
@@ -4,18 +4,28 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
-from typing import Iterable, List
+from typing import Iterable, List, Sequence, Tuple
 
 from .characters import AbilityScores
 from .dungeon import MonsterDefinition
 
 __all__ = [
+    "AdvantageState",
+    "Attack",
+    "AttackOutcome",
     "AttackRollResult",
     "Combatant",
+    "DamagePacket",
     "InitiativeResult",
+    "MultiattackResult",
     "SavingThrowResult",
     "ability_modifier",
+    "apply_damage",
     "attack_roll",
+    "compute_spell_save_dc",
+    "resolve_advantage_state",
+    "resolve_attack",
+    "resolve_multiattack",
     "roll_d20",
     "roll_initiative",
     "saving_throw",
@@ -78,6 +88,46 @@ def roll_initiative(
 
 
 @dataclass(frozen=True)
+class AdvantageState:
+    """Collapsed representation of advantage/disadvantage sources."""
+
+    advantage: bool
+    disadvantage: bool
+    advantage_sources: Tuple[str, ...] = ()
+    disadvantage_sources: Tuple[str, ...] = ()
+
+    @property
+    def is_neutral(self) -> bool:
+        return not self.advantage and not self.disadvantage
+
+
+def resolve_advantage_state(
+    advantage_sources: Sequence[str] | None = None,
+    disadvantage_sources: Sequence[str] | None = None,
+) -> AdvantageState:
+    """Collapse the provided sources into the final advantage state."""
+
+    advantages = tuple(advantage_sources or ())
+    disadvantages = tuple(disadvantage_sources or ())
+    has_advantage = bool(advantages)
+    has_disadvantage = bool(disadvantages)
+    if has_advantage and has_disadvantage:
+        # Advantage and disadvantage cancel out.
+        return AdvantageState(
+            advantage=False,
+            disadvantage=False,
+            advantage_sources=advantages,
+            disadvantage_sources=disadvantages,
+        )
+    return AdvantageState(
+        advantage=has_advantage,
+        disadvantage=has_disadvantage,
+        advantage_sources=advantages,
+        disadvantage_sources=disadvantages,
+    )
+
+
+@dataclass(frozen=True)
 class AttackRollResult:
     total: int
     roll: int
@@ -87,6 +137,35 @@ class AttackRollResult:
     hits: bool
 
 
+@dataclass(frozen=True)
+class DamagePacket:
+    amount: int
+    damage_type: str | None = None
+
+
+@dataclass(frozen=True)
+class Attack:
+    name: str
+    attack_bonus: int
+    damage_packets: Tuple[DamagePacket, ...]
+    advantage_sources: Tuple[str, ...] = ()
+    disadvantage_sources: Tuple[str, ...] = ()
+    critical_double: bool = True
+
+
+@dataclass(frozen=True)
+class AttackOutcome:
+    attack: Attack
+    roll_result: AttackRollResult
+    damage: int
+
+
+@dataclass(frozen=True)
+class MultiattackResult:
+    outcomes: Tuple[AttackOutcome, ...]
+    total_damage: int
+
+
 def attack_roll(
     attacker_bonus: int,
     target_armor_class: int,
@@ -94,8 +173,13 @@ def attack_roll(
     rng: random.Random | None = None,
     advantage: bool = False,
     disadvantage: bool = False,
+    advantage_state: AdvantageState | None = None,
 ) -> AttackRollResult:
     """Resolve an attack roll against a target's armor class."""
+
+    if advantage_state is not None:
+        advantage = advantage_state.advantage
+        disadvantage = advantage_state.disadvantage
 
     if advantage and disadvantage:
         advantage = disadvantage = False
@@ -146,8 +230,13 @@ def saving_throw(
     rng: random.Random | None = None,
     advantage: bool = False,
     disadvantage: bool = False,
+    advantage_state: AdvantageState | None = None,
 ) -> SavingThrowResult:
     """Resolve a saving throw against a difficulty class (DC)."""
+
+    if advantage_state is not None:
+        advantage = advantage_state.advantage
+        disadvantage = advantage_state.disadvantage
 
     if advantage and disadvantage:
         advantage = disadvantage = False
@@ -165,3 +254,108 @@ def saving_throw(
     success = total >= dc or natural == 20
 
     return SavingThrowResult(total=total, roll=roll, natural=natural, success=success)
+
+
+def apply_damage(
+    packets: Sequence[DamagePacket],
+    *,
+    resistances: Iterable[str] | None = None,
+    vulnerabilities: Iterable[str] | None = None,
+    immunities: Iterable[str] | None = None,
+) -> int:
+    """Calculate final damage after applying resistances and vulnerabilities."""
+
+    resistance_set = {damage_type.lower() for damage_type in (resistances or [])}
+    vulnerability_set = {damage_type.lower() for damage_type in (vulnerabilities or [])}
+    immunity_set = {damage_type.lower() for damage_type in (immunities or [])}
+
+    total = 0
+    for packet in packets:
+        amount = max(0, packet.amount)
+        if amount == 0:
+            continue
+        damage_type = packet.damage_type.lower() if packet.damage_type else None
+        if damage_type and damage_type in immunity_set:
+            continue
+        adjusted = amount
+        if damage_type:
+            resistant = damage_type in resistance_set
+            vulnerable = damage_type in vulnerability_set
+            if resistant and vulnerable:
+                # They cancel out.
+                resistant = vulnerable = False
+            if resistant:
+                adjusted = amount // 2
+            elif vulnerable:
+                adjusted = amount * 2
+        total += adjusted
+    return total
+
+
+def resolve_attack(
+    attack: Attack,
+    target_armor_class: int,
+    *,
+    rng: random.Random | None = None,
+    resistances: Iterable[str] | None = None,
+    vulnerabilities: Iterable[str] | None = None,
+    immunities: Iterable[str] | None = None,
+) -> AttackOutcome:
+    """Resolve a single attack and return the outcome along with damage dealt."""
+
+    advantage_state = resolve_advantage_state(
+        attack.advantage_sources, attack.disadvantage_sources
+    )
+    roll_result = attack_roll(
+        attack.attack_bonus,
+        target_armor_class,
+        rng=rng,
+        advantage_state=advantage_state,
+    )
+    damage = 0
+    if roll_result.hits:
+        damage = apply_damage(
+            attack.damage_packets,
+            resistances=resistances,
+            vulnerabilities=vulnerabilities,
+            immunities=immunities,
+        )
+        if roll_result.is_critical_hit and attack.critical_double:
+            damage *= 2
+
+    return AttackOutcome(attack=attack, roll_result=roll_result, damage=damage)
+
+
+def resolve_multiattack(
+    attacks: Sequence[Attack],
+    target_armor_class: int,
+    *,
+    rng: random.Random | None = None,
+    resistances: Iterable[str] | None = None,
+    vulnerabilities: Iterable[str] | None = None,
+    immunities: Iterable[str] | None = None,
+) -> MultiattackResult:
+    """Resolve a sequence of attacks and return the aggregated result."""
+
+    generator = rng or random
+    outcomes: List[AttackOutcome] = []
+    total_damage = 0
+    for attack in attacks:
+        outcome = resolve_attack(
+            attack,
+            target_armor_class,
+            rng=generator,
+            resistances=resistances,
+            vulnerabilities=vulnerabilities,
+            immunities=immunities,
+        )
+        outcomes.append(outcome)
+        total_damage += outcome.damage
+
+    return MultiattackResult(outcomes=tuple(outcomes), total_damage=total_damage)
+
+
+def compute_spell_save_dc(ability_mod: int, proficiency_bonus: int, *, base: int = 8) -> int:
+    """Compute the spell save DC using the provided ability modifier."""
+
+    return base + ability_mod + proficiency_bonus

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -1,0 +1,106 @@
+"""Unit coverage for combat helpers."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from dnd.combat import (
+    AdvantageState,
+    Attack,
+    DamagePacket,
+    apply_damage,
+    attack_roll,
+    compute_spell_save_dc,
+    resolve_advantage_state,
+    resolve_multiattack,
+)
+
+
+def test_resolve_advantage_state_collapses_sources() -> None:
+    state = resolve_advantage_state(["pack tactics"], [])
+    assert isinstance(state, AdvantageState)
+    assert state.advantage is True
+    assert state.disadvantage is False
+
+    neutral = resolve_advantage_state(["bless"], ["poisoned"])
+    assert neutral.is_neutral is True
+
+
+def test_attack_roll_uses_advantage_state() -> None:
+    rng = random.Random(1)
+    state = resolve_advantage_state(["ally help"], [])
+    result = attack_roll(0, 10, rng=rng, advantage_state=state)
+    # With the seeded RNG the rolls are 5 and 19; advantage selects the highest.
+    assert result.natural == 19
+
+    rng = random.Random(2)
+    disadvantage = resolve_advantage_state([], ["blinded"])
+    result = attack_roll(0, 10, rng=rng, advantage_state=disadvantage)
+    # Rolls are 2 and 3; disadvantage keeps the lowest.
+    assert result.natural == 2
+
+
+def test_apply_damage_with_resistance_and_vulnerability() -> None:
+    packets = [
+        DamagePacket(amount=10, damage_type="Fire"),
+        DamagePacket(amount=5, damage_type="Cold"),
+    ]
+    total = apply_damage(
+        packets,
+        resistances={"fire"},
+        vulnerabilities={"cold"},
+    )
+    # Fire is halved (rounded down) and cold is doubled.
+    assert total == 5 + 10
+
+    # Resistance and vulnerability of the same type cancel each other out.
+    neutral_total = apply_damage(
+        [DamagePacket(amount=12, damage_type="lightning")],
+        resistances={"lightning"},
+        vulnerabilities={"lightning"},
+    )
+    assert neutral_total == 12
+
+
+def test_resolve_multiattack_aggregates_damage() -> None:
+    rng = random.Random(0)
+    attacks = [
+        Attack(
+            name="Claw",
+            attack_bonus=5,
+            damage_packets=(DamagePacket(amount=7, damage_type="slashing"),),
+        ),
+        Attack(
+            name="Bite",
+            attack_bonus=5,
+            damage_packets=(DamagePacket(amount=10, damage_type="piercing"),),
+            advantage_sources=("pack tactics",),
+        ),
+    ]
+
+    result = resolve_multiattack(
+        attacks,
+        15,
+        rng=rng,
+        resistances={"slashing"},
+        vulnerabilities={"piercing"},
+    )
+
+    # First attack hits (13+5) and deals 7 -> 3 after resistance.
+    # Second attack rolls with advantage taking 14 over 2 for a hit and deals 10 -> 20.
+    assert result.total_damage == 23
+    assert len(result.outcomes) == 2
+    assert [outcome.damage for outcome in result.outcomes] == [3, 20]
+
+
+@pytest.mark.parametrize(
+    "ability_score, proficiency_bonus, expected",
+    [(16, 3, 14), (18, 4, 16)],
+)
+def test_compute_spell_save_dc(ability_score: int, proficiency_bonus: int, expected: int) -> None:
+    from dnd.combat import ability_modifier
+
+    ability_mod = ability_modifier(ability_score)
+    assert compute_spell_save_dc(ability_mod, proficiency_bonus) == expected


### PR DESCRIPTION
## Summary
- add advantage state, damage packet, and attack data structures with helpers for spell save DCs
- expose attack resolution, multiattack, and damage application APIs to support the dungeon cog
- cover advantage math, resistances, and multiattack totals with new combat unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dce2b988a48329950cbea69cb551bd