### PR TITLE
Ensure persistent dungeon views have custom IDs

### DIFF
--- a/cogs/dungeon.py
+++ b/cogs/dungeon.py
@@ -339,6 +339,7 @@ class DungeonNavigationView(discord.ui.View):
         button = discord.ui.Button(
             label=f"Status: {status_label}",
             style=style,
+            custom_id=f"dungeon:status:{session.channel_id}",
             disabled=True,
         )
         self.add_item(button)
@@ -432,6 +433,7 @@ class CombatActionView(discord.ui.View):
         button = discord.ui.Button(
             label=f"Status: {status_label}",
             style=style,
+            custom_id=f"dungeon:combat:status:{session.channel_id}",
             disabled=True,
         )
         self.add_item(button)


### PR DESCRIPTION
## Summary
- assign custom component IDs to the status indicator buttons in dungeon navigation and combat views so they can be registered as persistent views

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd6737b22c8329ad9ed762f7d90f7e