### PR TITLE
Remove manual language selection from character creation

### DIFF
--- a/docs/character_creation.md
+++ b/docs/character_creation.md
@@ -11,8 +11,7 @@ process that mirrors the official SRD onboarding rules.
    default languages.
 3. **Class Configuration** – Choose a class, then select the exact number of
    skill proficiencies required by that class.
-4. **Background & Languages** – Choose a background and satisfy any additional
-   language proficiencies granted by it.
+4. **Background** – Choose a background to gain the listed proficiencies.
 5. **Starting Equipment** – Resolve every class equipment choice (each option is
    drawn from the SRD starting packages) before continuing.
 6. **Confirmation** – Review the full summary (ability scores, proficiencies,

--- a/tests/test_character_models.py
+++ b/tests/test_character_models.py
@@ -34,7 +34,6 @@ def test_character_serialization_round_trip() -> None:
     state.set_class_skills(["Athletics", "Perception"])
     state.set_equipment_choice("fighter_weapon", ["fighter_defense"])
     state.set_background("acolyte")
-    state.set_background_languages(["Giant", "Gnomish"])
     assert state.current_step() == 6
     assert state.is_ready()
 
@@ -64,6 +63,5 @@ def test_creation_state_validations() -> None:
     state.set_class_skills(["Arcana", "History"])
     state.set_equipment_choice("wizard_focus", ["wizard_component"])
     state.set_background("soldier")
-    assert state.needs_background_languages() is False
     assert state.needs_equipment() is False
     assert state.current_step() == 6


### PR DESCRIPTION
## Summary
- remove the background language selection modal and related state from character creation
- rely solely on race data for language assignment and simplify background step messaging
- update documentation and tests to reflect automatic language handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dda397e0388329ba912a7306f47121