### PR TITLE
Add perception flow for hidden dungeon content

### DIFF
--- a/tests/test_dungeon_traps.py
+++ b/tests/test_dungeon_traps.py
@@ -12,6 +12,7 @@ if str(ROOT) not in sys.path:
 
 from cogs import dungeon as dungeon_module
 from cogs.dungeon import DungeonCog, DungeonSession
+from dnd.content import Item
 from dnd.content.models import EncounterTable, Theme, Trap
 from dnd.dungeon.generator import Dungeon, EncounterResult, Room, RoomExit
 from dnd.sessions import SessionManager
@@ -68,31 +69,38 @@ def _make_cog(monkeypatch: pytest.MonkeyPatch) -> DungeonCog:
     return cog
 
 
-def _make_trap_session(user_id: int = 100) -> DungeonSession:
-    trap = Trap(
+def _make_trap_session(
+    user_id: int = 100,
+    *,
+    traps: tuple[Trap, ...] | None = None,
+    loot: tuple[Item, ...] = (),
+    exits: tuple[RoomExit, ...] | None = None,
+) -> DungeonSession:
+    default_trap = Trap(
         key="pit",
         name="Hidden Pit",
         description="A concealed pit trap.",
         saving_throw={"ability": "DEX", "dc": 13},
         damage="2d6 bludgeoning",
     )
+    trap_pool = traps if traps is not None else (default_trap,)
+    exit_pool = exits if exits is not None else (RoomExit(key="forward", label="Forward", destination=0),)
     trap_encounter = EncounterResult(
         kind="trap",
         summary="A precarious hazard lurks here.",
-        traps=(trap,),
-        loot=(),
+        traps=trap_pool,
+        loot=loot,
         monsters=(),
     )
-    exits = (RoomExit(key="forward", label="Forward", destination=0),)
-    room = Room(id=0, name="Trap Room", description="", encounter=trap_encounter, exits=exits)
+    room = Room(id=0, name="Trap Room", description="", encounter=trap_encounter, exits=exit_pool)
     theme = Theme(
         key="test",
         name="Test",
         description="",
         room_templates=(),
         monsters=(),
-        traps=(trap,),
-        loot=(),
+        traps=trap_pool or (default_trap,),
+        loot=loot,
         encounter_table=EncounterTable({"trap": 1}),
     )
     dungeon = Dungeon(
@@ -108,38 +116,70 @@ def _make_trap_session(user_id: int = 100) -> DungeonSession:
     return session
 
 
+def _find_field(embed, name: str):
+    for field in embed.fields:
+        if field.name == name:
+            return field
+    return None
+
+
 def test_trap_hidden_until_detected(monkeypatch: pytest.MonkeyPatch) -> None:
     cog = _make_cog(monkeypatch)
     session = _make_trap_session()
     cog._ensure_room_trap_state(session, session.room)
+    session.discovered_exits.setdefault(session.room.id, set()).update(
+        exit_option.key for exit_option in session.room.exits
+    )
 
     embed = cog._build_room_embed(None, session)
-    assert all(field.name != "Traps" for field in embed.fields)
+    assert _find_field(embed, "Traps") is None
+
+    interaction = DummyInteraction()
+    key = cog._session_key(interaction.guild_id, interaction.channel_id)
+
+    async def runner() -> None:
+        await cog.sessions.set(key, session)
+        results = iter(
+            [
+                dungeon_module.SavingThrowResult(total=18, roll=18, natural=18, success=True),
+            ]
+        )
+
+        def fake_saving_throw(*_args, **_kwargs):
+            try:
+                return next(results)
+            except StopIteration:
+                return dungeon_module.SavingThrowResult(total=1, roll=1, natural=1, success=False)
+
+        monkeypatch.setattr(dungeon_module, "saving_throw", fake_saving_throw)
+        await cog.handle_perception(interaction)
+
+    asyncio.run(runner())
+
+    detected_embed = cog._build_room_embed(None, session)
+    trap_field = _find_field(detected_embed, "Traps")
+    assert trap_field is not None
+    assert "detected" in trap_field.value
 
     trap = session.room.encounter.traps[0]
     room_id = session.room.id
-    session.trap_catalog.setdefault(room_id, {})[trap.key] = trap
-    session.trap_states.setdefault(room_id, {})[trap.key] = "discovered"
-
-    detected_embed = cog._build_room_embed(None, session)
-    trap_field = next(field for field in detected_embed.fields if field.name == "Traps")
-    assert trap.name in trap_field.value
-    assert "detected" in trap_field.value
-
-    session.trap_states[room_id][trap.key] = "sprung"
+    session.trap_states.setdefault(room_id, {})[trap.key] = "sprung"
     session.room.encounter = replace(session.room.encounter, traps=())
 
     sprung_embed = cog._build_room_embed(None, session)
-    sprung_field = next(field for field in sprung_embed.fields if field.name == "Traps")
+    sprung_field = _find_field(sprung_embed, "Traps")
+    assert sprung_field is not None
     assert "sprung" in sprung_field.value
 
 
 def test_failed_disarm_triggers_damage(monkeypatch: pytest.MonkeyPatch) -> None:
     cog = _make_cog(monkeypatch)
     session = _make_trap_session()
+    session.discovered_exits.setdefault(session.room.id, set()).update(
+        exit_option.key for exit_option in session.room.exits
+    )
     interaction = DummyInteraction()
     key = cog._session_key(interaction.guild_id, interaction.channel_id)
-    trap_key = session.room.encounter.traps[0].key
 
     async def runner() -> None:
         await cog.sessions.set(key, session)
@@ -148,17 +188,19 @@ def test_failed_disarm_triggers_damage(monkeypatch: pytest.MonkeyPatch) -> None:
             [
                 dungeon_module.SavingThrowResult(total=18, roll=18, natural=18, success=True),
                 dungeon_module.SavingThrowResult(total=5, roll=5, natural=5, success=False),
-                dungeon_module.SavingThrowResult(total=8, roll=8, natural=8, success=False),
             ]
         )
 
         def fake_saving_throw(*_args, **_kwargs):
-            return next(results)
+            try:
+                return next(results)
+            except StopIteration:
+                return dungeon_module.SavingThrowResult(total=1, roll=1, natural=1, success=False)
 
         monkeypatch.setattr(dungeon_module, "saving_throw", fake_saving_throw)
         monkeypatch.setattr(cog, "_roll_damage", lambda *_args, **_kwargs: 6)
 
-        await cog.handle_disarm(interaction)
+        await cog.handle_perception(interaction)
         await cog.handle_disarm(interaction)
 
     asyncio.run(runner())
@@ -173,9 +215,12 @@ def test_failed_disarm_triggers_damage(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "damage" in last_message
 
 
-def test_failed_detection_keeps_trap_hidden(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_failed_perception_keeps_trap_hidden(monkeypatch: pytest.MonkeyPatch) -> None:
     cog = _make_cog(monkeypatch)
     session = _make_trap_session()
+    session.discovered_exits.setdefault(session.room.id, set()).update(
+        exit_option.key for exit_option in session.room.exits
+    )
     interaction = DummyInteraction()
     key = cog._session_key(interaction.guild_id, interaction.channel_id)
     user_id = interaction.user.id
@@ -190,11 +235,14 @@ def test_failed_detection_keeps_trap_hidden(monkeypatch: pytest.MonkeyPatch) -> 
         )
 
         def fake_saving_throw(*_args, **_kwargs):
-            return next(results)
+            try:
+                return next(results)
+            except StopIteration:
+                return dungeon_module.SavingThrowResult(total=1, roll=1, natural=1, success=False)
 
         monkeypatch.setattr(dungeon_module, "saving_throw", fake_saving_throw)
 
-        await cog.handle_disarm(interaction)
+        await cog.handle_perception(interaction)
 
     asyncio.run(runner())
 
@@ -202,16 +250,19 @@ def test_failed_detection_keeps_trap_hidden(monkeypatch: pytest.MonkeyPatch) -> 
     trap_key = session.room.encounter.traps[0].key
     assert session.trap_states[room_id][trap_key] == "hidden"
     assert session.room.encounter.traps
-    attempts = session.trap_detection_attempts[room_id][user_id]
+    attempts = session.perception_attempts[room_id][user_id]
     assert attempts == 1
     assert interaction.followup.sent_messages
     message = interaction.followup.sent_messages[-1]
     assert "fail to spot" in message
 
 
-def test_detection_limit_blocks_additional_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_perception_attempt_limit_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
     cog = _make_cog(monkeypatch)
     session = _make_trap_session()
+    session.discovered_exits.setdefault(session.room.id, set()).update(
+        exit_option.key for exit_option in session.room.exits
+    )
     interaction = DummyInteraction()
     key = cog._session_key(interaction.guild_id, interaction.channel_id)
     user_id = interaction.user.id
@@ -227,19 +278,22 @@ def test_detection_limit_blocks_additional_checks(monkeypatch: pytest.MonkeyPatc
         )
 
         def fake_saving_throw(*_args, **_kwargs):
-            return next(results)
+            try:
+                return next(results)
+            except StopIteration:
+                return dungeon_module.SavingThrowResult(total=1, roll=1, natural=1, success=False)
 
         monkeypatch.setattr(dungeon_module, "saving_throw", fake_saving_throw)
 
-        await cog.handle_disarm(interaction)
-        await cog.handle_disarm(interaction)
-        await cog.handle_disarm(interaction)
+        await cog.handle_perception(interaction)
+        await cog.handle_perception(interaction)
+        await cog.handle_perception(interaction)
 
     asyncio.run(runner())
 
     room_id = session.room.id
     trap_key = session.room.encounter.traps[0].key
-    attempts = session.trap_detection_attempts[room_id][user_id]
+    attempts = session.perception_attempts[room_id][user_id]
     assert attempts == dungeon_module.MAX_TRAP_DETECTION_ATTEMPTS
     assert session.trap_states[room_id][trap_key] == "hidden"
     assert session.room.encounter.traps
@@ -250,6 +304,9 @@ def test_detection_limit_blocks_additional_checks(monkeypatch: pytest.MonkeyPatc
 def test_successful_detection_and_disarm_updates_state(monkeypatch: pytest.MonkeyPatch) -> None:
     cog = _make_cog(monkeypatch)
     session = _make_trap_session()
+    session.discovered_exits.setdefault(session.room.id, set()).update(
+        exit_option.key for exit_option in session.room.exits
+    )
     interaction = DummyInteraction()
     key = cog._session_key(interaction.guild_id, interaction.channel_id)
     trap_key = session.room.encounter.traps[0].key
@@ -265,11 +322,14 @@ def test_successful_detection_and_disarm_updates_state(monkeypatch: pytest.Monke
         )
 
         def fake_saving_throw(*_args, **_kwargs):
-            return next(results)
+            try:
+                return next(results)
+            except StopIteration:
+                return dungeon_module.SavingThrowResult(total=1, roll=1, natural=1, success=False)
 
         monkeypatch.setattr(dungeon_module, "saving_throw", fake_saving_throw)
 
-        await cog.handle_disarm(interaction)
+        await cog.handle_perception(interaction)
         await cog.handle_disarm(interaction)
 
     asyncio.run(runner())
@@ -280,3 +340,149 @@ def test_successful_detection_and_disarm_updates_state(monkeypatch: pytest.Monke
     assert interaction.followup.sent_messages
     assert "uncover" in interaction.followup.sent_messages[0]
     assert "disarm" in interaction.followup.sent_messages[-1]
+
+
+def test_loot_hidden_until_discovered(monkeypatch: pytest.MonkeyPatch) -> None:
+    loot_item = Item(key="amulet", name="Jeweled Amulet", rarity="Rare")
+    cog = _make_cog(monkeypatch)
+    session = _make_trap_session(traps=(), loot=(loot_item,))
+    interaction = DummyInteraction()
+    key = cog._session_key(interaction.guild_id, interaction.channel_id)
+    session.discovered_exits.setdefault(session.room.id, set()).update(
+        exit_option.key for exit_option in session.room.exits
+    )
+
+    embed = cog._build_room_embed(None, session)
+    assert _find_field(embed, "Loot") is None
+
+    async def runner() -> None:
+        await cog.sessions.set(key, session)
+        await cog.handle_search(interaction)
+
+    asyncio.run(runner())
+
+    assert session.room.encounter.loot == (loot_item,)
+    assert "nothing of value" in interaction.followup.sent_messages[-1]
+
+    interaction.followup.sent_messages.clear()
+
+    async def discover_and_search() -> None:
+        await cog.sessions.set(key, session)
+        results = iter(
+            [
+                dungeon_module.SavingThrowResult(total=16, roll=16, natural=16, success=True),
+            ]
+        )
+
+        def fake_saving_throw(*_args, **_kwargs):
+            try:
+                return next(results)
+            except StopIteration:
+                return dungeon_module.SavingThrowResult(total=1, roll=1, natural=1, success=False)
+
+        monkeypatch.setattr(dungeon_module, "saving_throw", fake_saving_throw)
+
+        await cog.handle_perception(interaction)
+        await cog.handle_search(interaction)
+
+    asyncio.run(discover_and_search())
+
+    embed_after = cog._build_room_embed(None, session)
+    loot_field = _find_field(embed_after, "Loot")
+    assert loot_field is not None
+    assert loot_item.name in loot_field.value
+    assert session.room.encounter.loot == (loot_item,)
+    assert any("guild roster" in message for message in interaction.followup.sent_messages)
+
+
+def test_exit_hidden_until_discovered(monkeypatch: pytest.MonkeyPatch) -> None:
+    secret_exit = RoomExit(key="secret", label="Secret Door", destination=0)
+    cog = _make_cog(monkeypatch)
+    session = _make_trap_session(traps=(), loot=(), exits=(secret_exit,))
+    interaction = DummyInteraction()
+    key = cog._session_key(interaction.guild_id, interaction.channel_id)
+
+    embed = cog._build_room_embed(None, session)
+    exit_field = _find_field(embed, "Exits")
+    assert exit_field is not None
+    assert "No obvious exits" in exit_field.value
+
+    async def runner() -> None:
+        await cog.sessions.set(key, session)
+        results = iter(
+            [
+                dungeon_module.SavingThrowResult(total=17, roll=17, natural=17, success=True),
+            ]
+        )
+
+        def fake_saving_throw(*_args, **_kwargs):
+            try:
+                return next(results)
+            except StopIteration:
+                return dungeon_module.SavingThrowResult(total=1, roll=1, natural=1, success=False)
+
+        monkeypatch.setattr(dungeon_module, "saving_throw", fake_saving_throw)
+        await cog.handle_perception(interaction)
+
+    asyncio.run(runner())
+
+    embed_after = cog._build_room_embed(None, session)
+    exit_field_after = _find_field(embed_after, "Exits")
+    assert exit_field_after is not None
+    assert "Secret Door" in exit_field_after.value
+
+
+def test_disarm_button_requires_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    cog = _make_cog(monkeypatch)
+    session = _make_trap_session()
+
+    async def _build_view(target_session: DungeonSession):
+        return dungeon_module.DungeonNavigationView(cog, target_session)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        view = loop.run_until_complete(_build_view(session))
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+    disarm_button = next(
+        item for item in view.children if getattr(item, "custom_id", None) == "dungeon:disarm"
+    )
+    assert disarm_button.disabled
+
+    interaction = DummyInteraction()
+    key = cog._session_key(interaction.guild_id, interaction.channel_id)
+
+    async def runner() -> None:
+        await cog.sessions.set(key, session)
+        results = iter(
+            [
+                dungeon_module.SavingThrowResult(total=18, roll=18, natural=18, success=True),
+            ]
+        )
+
+        def fake_saving_throw(*_args, **_kwargs):
+            try:
+                return next(results)
+            except StopIteration:
+                return dungeon_module.SavingThrowResult(total=1, roll=1, natural=1, success=False)
+
+        monkeypatch.setattr(dungeon_module, "saving_throw", fake_saving_throw)
+        await cog.handle_perception(interaction)
+
+    asyncio.run(runner())
+
+    updated_session = asyncio.run(cog.sessions.get(key))
+    assert updated_session is not None
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        view_after = loop.run_until_complete(_build_view(updated_session))
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+    disarm_button_after = next(
+        item for item in view_after.children if getattr(item, "custom_id", None) == "dungeon:disarm"
+    )
+    assert not disarm_button_after.disabled


### PR DESCRIPTION
## Summary
- track per-room discovery state for traps, loot, and exits and expose a Perception action in the dungeon navigation view
- implement a dedicated handle_perception flow while updating search, disarm, and exit logic to respect newly discovered content
- extend dungeon trap tests to cover perception gating for traps, loot, exits, and the disarm button

## Testing
- pytest tests/test_dungeon_traps.py

------
https://chatgpt.com/codex/tasks/task_e_68ddf51435c0832998e725e331630557