### PR TITLE
Render ASCII dungeon boxes with corridors

### DIFF
--- a/tests/test_dungeon_map.py
+++ b/tests/test_dungeon_map.py
@@ -9,7 +9,7 @@ if str(ROOT) not in sys.path:
 
 from cogs.dungeon import DungeonCog, DungeonSession
 from dnd.content.models import EncounterTable, Theme
-from dnd.dungeon.generator import Dungeon, EncounterResult, Room
+from dnd.dungeon.generator import Corridor, Dungeon, EncounterResult, Room
 
 
 @pytest.fixture()
@@ -20,6 +20,14 @@ def simple_session() -> DungeonSession:
     positions = {0: (0, 0), 1: (1, 0)}
     room_a.position = positions[0]
     room_b.position = positions[1]
+
+    corridor = Corridor(
+        from_room=0,
+        to_room=1,
+        description="",
+        from_label="Left-hand passage",
+        to_label="Right-hand passage",
+    )
 
     theme = Theme(
         key="test",
@@ -37,7 +45,7 @@ def simple_session() -> DungeonSession:
         theme=theme,
         difficulty="standard",
         rooms=(room_a, room_b),
-        corridors=(),
+        corridors=(corridor,),
         room_positions=positions,
     )
     return DungeonSession(dungeon=dungeon, guild_id=None, channel_id=1)
@@ -49,6 +57,8 @@ def test_map_highlights_current_room(simple_session: DungeonSession) -> None:
     first_map = cog._build_map_string(simple_session)
     assert "[01]" in first_map
     assert " 02" in first_map
+    assert "+----+" in first_map
+    assert "+--+" in first_map
 
     simple_session.current_room = 1
     second_map = cog._build_map_string(simple_session)
@@ -65,3 +75,49 @@ def test_session_embeds_include_map_first(simple_session: DungeonSession) -> Non
     assert embeds[0].description is not None
     assert "```" in embeds[0].description
     assert any(embed.title and "Room" in embed.title for embed in embeds[1:])
+
+
+def test_map_draws_vertical_corridors() -> None:
+    empty_encounter = EncounterResult(kind="empty", summary="Quiet chamber.")
+    rooms = [
+        Room(id=0, name="Alpha", description="", encounter=empty_encounter),
+        Room(id=1, name="Beta", description="", encounter=empty_encounter),
+    ]
+    positions = {0: (0, 0), 1: (0, 1)}
+    for room in rooms:
+        room.position = positions[room.id]
+
+    corridor = Corridor(
+        from_room=0,
+        to_room=1,
+        description="",
+        from_label="Ascending stair",
+        to_label="Descending stair",
+    )
+
+    theme = Theme(
+        key="test",
+        name="Test Theme",
+        description="",
+        room_templates=(),
+        monsters=(),
+        traps=(),
+        loot=(),
+        encounter_table=EncounterTable({"empty": 1}),
+    )
+    dungeon = Dungeon(
+        name="Tower", 
+        seed=None,
+        theme=theme,
+        difficulty="standard",
+        rooms=tuple(rooms),
+        corridors=(corridor,),
+        room_positions=positions,
+    )
+    session = DungeonSession(dungeon=dungeon, guild_id=None, channel_id=99)
+    cog = DungeonCog.__new__(DungeonCog)
+    map_string = cog._build_map_string(session)
+
+    assert "[01]" in map_string or "[02]" in map_string
+    assert "+----+" in map_string
+    assert "   |" in map_string


### PR DESCRIPTION
## Summary
- draw dungeon rooms as multi-line ASCII boxes with padded corridors
- route dungeon corridor connections through ASCII hallways with clean intersections
- expand dungeon map tests to cover new layout, including corridors

## Testing
- pytest tests/test_dungeon_map.py

------
https://chatgpt.com/codex/tasks/task_e_68de0725dc20832985d3097254d18015