### PR TITLE
Stop revealing hidden clues on failed searches

### DIFF
--- a/cogs/dungeon.py
+++ b/cogs/dungeon.py
@@ -4815,22 +4815,6 @@ class DungeonCog(commands.Cog):
             else:
                 message_lines.append(f"You reveal a hidden exit: {name}! {summary}")
 
-        if failures:
-            if successes:
-                message_lines.append("")
-            for kind, name, roll, dc, _ability in failures:
-                summary = f"(Perception roll {roll.total} vs DC {dc})"
-                if kind == "trap":
-                    message_lines.append(f"You fail to spot any hidden dangers {summary}.")
-                elif kind == "loot":
-                    message_lines.append(
-                        f"You fail to uncover any hidden treasure {summary}."
-                    )
-                else:
-                    message_lines.append(
-                        f"You fail to notice any hidden passages {summary}."
-                    )
-
         if not successes:
             message_lines.append(
                 "You can try again, though each failure may make the search more challenging."

--- a/tests/test_dungeon_traps.py
+++ b/tests/test_dungeon_traps.py
@@ -308,7 +308,8 @@ def test_failed_perception_keeps_trap_hidden(monkeypatch: pytest.MonkeyPatch) ->
     assert attempts == 1
     assert interaction.followup.sent_messages
     message = interaction.followup.sent_messages[-1]
-    assert "fail to spot" in message
+    assert "fail to spot" not in message
+    assert "fail to uncover" not in message
     assert "scoured" not in message
     assert "try again" in message
 


### PR DESCRIPTION
## Summary
- remove perception failure text so hidden traps, loot, and exits stay unmentioned when undetected
- update failing perception test expectations to ensure no hidden clues leak into responses

## Testing
- pytest tests/test_dungeon_traps.py

------
https://chatgpt.com/codex/tasks/task_e_68de567561d48329a6b78a080b663e5c