### PR TITLE
Add low-CR constructs and ensure easy Arcane Ruins uses them

### DIFF
--- a/data/monsters/constructs.json
+++ b/data/monsters/constructs.json
@@ -1,5 +1,27 @@
 [
   {
+    "key": "animated_broom",
+    "name": "Animated Broom",
+    "challenge": 0.25,
+    "armor_class": 15,
+    "hit_points": 17,
+    "attack_bonus": 4,
+    "damage": "1d4+2",
+    "ability_scores": {"STR": 10, "DEX": 16, "CON": 12},
+    "tags": ["construct", "arcane", "minion"]
+  },
+  {
+    "key": "flying_sword",
+    "name": "Flying Sword",
+    "challenge": 1,
+    "armor_class": 17,
+    "hit_points": 17,
+    "attack_bonus": 3,
+    "damage": "1d8+1",
+    "ability_scores": {"STR": 12, "DEX": 15, "CON": 11},
+    "tags": ["construct", "arcane", "skirmisher"]
+  },
+  {
     "key": "animated_armor",
     "name": "Animated Armor",
     "challenge": 3,

--- a/data/themes/arcane_ruins.json
+++ b/data/themes/arcane_ruins.json
@@ -25,9 +25,11 @@
     }
   ],
   "monsters": [
-    "animated_armor",
-    "specter",
-    "helmed_horror"
+    {"key": "animated_broom", "weight": 2},
+    {"key": "flying_sword", "weight": 2},
+    {"key": "animated_armor", "weight": 1},
+    {"key": "helmed_horror", "weight": 1},
+    {"key": "specter", "weight": 1}
   ],
   "traps": [
     "glyph_of_detonation",

--- a/tests/test_dungeon_generator.py
+++ b/tests/test_dungeon_generator.py
@@ -108,6 +108,27 @@ def test_monster_challenge_bounds_applied(arcane_theme: Theme) -> None:
     assert exceeds_cap, "Harder tiers should still surface high-CR monsters"
 
 
+def test_easy_arcane_ruins_encounters_use_low_cr_constructs(arcane_theme: Theme) -> None:
+    easy_profile = DIFFICULTY_PROFILES["easy"]
+    assert easy_profile.max_monster_challenge is not None
+
+    low_cr_monsters = {
+        monster.key
+        for monster in arcane_theme.monsters
+        if monster.challenge <= easy_profile.max_monster_challenge
+    }
+    assert {"animated_broom", "flying_sword"}.issubset(low_cr_monsters)
+
+    encountered: set[str] = set()
+    for seed in range(60):
+        generator = DungeonGenerator(arcane_theme, seed=seed, difficulty="easy")
+        encounter = generator._build_encounter("combat", "easy")
+        encountered.update(monster.key for monster in encounter.monsters)
+        assert all(monster.challenge <= easy_profile.max_monster_challenge for monster in encounter.monsters)
+
+    assert encountered <= low_cr_monsters
+
+
 def test_trap_scaling_by_difficulty(arcane_theme: Theme) -> None:
     difficulties = list(DIFFICULTY_PROFILES.keys())
     average_counts: list[float] = []


### PR DESCRIPTION
## Summary
- add animated broom and flying sword stat blocks to the constructs content pack
- update the Arcane Ruins theme to reference the new low-CR constructs with higher weights
- add a regression test that keeps easy Arcane Ruins combats capped at CR 2

## Testing
- pytest tests/test_dungeon_generator.py::test_easy_arcane_ruins_encounters_use_low_cr_constructs

------
https://chatgpt.com/codex/tasks/task_e_68e16b9ea6908329840b2c2de430bc53