### PR TITLE
Add tavern category and multi-channel configuration

### DIFF
--- a/cogs/dungeon.py
+++ b/cogs/dungeon.py
@@ -4397,7 +4397,10 @@ class DungeonCog(commands.Cog):
         guild = self.bot.get_guild(guild_id)
         if guild is None:
             return None
-        channel = guild.get_channel(config.channel_id)
+        channel_id = config.tavern_channel_id or config.channel_id
+        if channel_id is None:
+            return None
+        channel = guild.get_channel(channel_id)
         return channel if isinstance(channel, discord.TextChannel) else None
 
     @staticmethod


### PR DESCRIPTION
## Summary
- extend the tavern configuration store to retain category, manage-channel, and tavern-channel identifiers while migrating legacy JSON payloads
- replace the /tavern set command so it provisions or reuses a category with dedicated #manage-character and #tavern channels and saves their identifiers
- refresh tavern bootstrap logic to sync permissions for both channels and update dungeon lookups for the new configuration shape

## Testing
- pytest *(fails: tests/test_dungeon_generator.py::test_combat_scaling_by_difficulty)*
- pytest tests/test_dungeon_generator.py::test_combat_scaling_by_difficulty *(fails: tests/test_dungeon_generator.py::test_combat_scaling_by_difficulty)*

------
https://chatgpt.com/codex/tasks/task_e_68e3017722d88329ad4c055fcfcf54d6