### PR TITLE
Filter Join Party options to active non-full parties

### DIFF
--- a/cogs/tavern.py
+++ b/cogs/tavern.py
@@ -889,9 +889,14 @@ class TavernControlView(discord.ui.View):
             return
 
         parties = manager.parties()
-        available = [party for party in parties if len(party.members) < manager.max_size]
+        active_parties = [party for party in parties if party.members]
+        available = [
+            party
+            for party in active_parties
+            if len(party.members) < manager.max_size
+        ]
 
-        if not parties:
+        if not active_parties:
             await interaction.response.send_message(
                 "No parties are gathering yet. Use **Create Party** to start one.",
                 ephemeral=True,


### PR DESCRIPTION
## Summary
- ensure the Join Party control only lists active parties with at least one member
- filter the selection to exclude parties that have already reached the size limit

## Testing
- pytest tests/test_tavern_lobby.py

------
https://chatgpt.com/codex/tasks/task_e_68e3110271488329b55d3335f95b14b1