### PR TITLE
Convert corridors into interactive rooms

### DIFF
--- a/tests/test_dungeon_generator.py
+++ b/tests/test_dungeon_generator.py
@@ -209,6 +209,30 @@ def test_generate_builds_branching_graph(arcane_theme: Theme) -> None:
         )
 
 
+def test_generate_adds_interactive_corridor_rooms(arcane_theme: Theme) -> None:
+    generator = DungeonGenerator(arcane_theme, seed=187)
+    dungeon = generator.generate(room_count=4)
+
+    corridor_rooms = [room for room in dungeon.rooms if room.is_corridor]
+    assert corridor_rooms, "Corridor rooms should be generated for each passage"
+
+    for corridor_room in corridor_rooms:
+        assert corridor_room.encounter is not None
+        assert corridor_room.exits, "Corridor rooms should provide exits"
+        destinations = {
+            exit_option.destination
+            for exit_option in corridor_room.exits
+            if exit_option.destination is not None
+        }
+        assert destinations, "Corridor rooms should lead somewhere"
+        assert corridor_room.id not in destinations
+        assert corridor_room.description
+
+    for corridor in dungeon.corridors:
+        assert dungeon.get_room(corridor.from_room)
+        assert dungeon.get_room(corridor.to_room)
+
+
 def test_generated_corridors_allow_backtracking(arcane_theme: Theme) -> None:
     generator = DungeonGenerator(arcane_theme, seed=104)
     dungeon = generator.generate(room_count=6)


### PR DESCRIPTION
## Summary
- turn each generated corridor into an explicit corridor room with encounters, corridor exits, and scaled map positions
- mark rooms with an `is_corridor` flag, tighten challenging difficulty monster floors, and ensure the farthest delve exit ignores corridor rooms
- add a regression test asserting corridor rooms are generated with usable exits

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e31594dc388329b43c52d74f9dac30